### PR TITLE
Small fix: val.strip() does not do anything because python strip returns...

### DIFF
--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -283,7 +283,7 @@ class BibTexParser(object):
         :type val: string
         :returns: string -- value
         """
-        val.strip()
+        val = val.strip()
         if val.startswith('{') and val.endswith('}'):
             return val[1:-1]
         return val


### PR DESCRIPTION
... a copy of the string. The author meant val = val.strip()
