### PR TITLE
Fix identifier regex

### DIFF
--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -96,7 +96,7 @@ class BibTexParser(object):
             'subjects': 'subject'
         }
 
-        self.replace_all_re = re.compile(r'((?P<pre>"?)\s*(#|^)\s*(?P<id>[^\d\W]\w*)\s*(#|$)\s*(?P<post>"?))', re.UNICODE)
+        self.replace_all_re = re.compile(r'((?P<pre>"?)\s*(#|^)\s*(?P<id>[^\d\000-\037 "#%\'(),={}][^\000-\037 "#%\'(),={}]*)\s*(#|$)\s*(?P<post>"?))', re.UNICODE)
 
     def _bibtex_file_obj(self, bibtex_str):
         # Some files have Byte-order marks inserted at the start


### PR DESCRIPTION
The replace_all_re regex did not allow string identifiers with dashes, amongst other allowed special characters.

Relevant bit of http://ftp.math.utah.edu/pub/tex/bibtex/bibtex.web (couldn't find the parser in a more recent TeX distro...):

for i:=0 to @'177 do id_class[i] := legal_id_char;
for i:=0 to @'37 do id_class[i] := illegal_id_char;
id_class[space] := illegal_id_char;
id_class[tab] := illegal_id_char;
id_class[double_quote] := illegal_id_char;
id_class[number_sign] := illegal_id_char;
id_class[comment] := illegal_id_char;
id_class[single_quote] := illegal_id_char;
id_class[left_paren] := illegal_id_char;
id_class[right_paren] := illegal_id_char;
id_class[comma] := illegal_id_char;
id_class[equals_sign] := illegal_id_char;
id_class[left_brace] := illegal_id_char;
id_class[right_brace] := illegal_id_char;