### PR TITLE
[WIP] Regression comments starting with % and no final coma

### DIFF
--- a/bibtexparser/tests/data/comments_percentage.bib
+++ b/bibtexparser/tests/data/comments_percentage.bib
@@ -1,0 +1,19 @@
+@ARTICLE{Cesar2013,
+  author = {Jean Cesar},
+  title = {An amazing title},
+  year = {2013},
+  volume = {12},
+  journal = {Nice Journal},
+  comments = {A comment},
+  keyword = {keyword1, keyword2},
+}
+% comment.
+@ARTICLE{Baltazar2013,
+  author = {Jean Baltazar},
+  title = {An amazing title},
+  year = {2013},
+  volume = {12},
+  journal = {Nice Journal},
+  comments = {A comment},
+  keyword = {keyword1, keyword2},
+}

--- a/bibtexparser/tests/data/comments_percentage_nolastcoma.bib
+++ b/bibtexparser/tests/data/comments_percentage_nolastcoma.bib
@@ -1,0 +1,19 @@
+@ARTICLE{Cesar2013,
+  author = {Jean Cesar},
+  title = {An amazing title},
+  year = {2013},
+  volume = {12},
+  journal = {Nice Journal},
+  comments = {A comment},
+  keyword = {keyword1, keyword2}
+}
+% comment.
+@ARTICLE{Baltazar2013,
+  author = {Jean Baltazar},
+  title = {An amazing title},
+  year = {2013},
+  volume = {12},
+  journal = {Nice Journal},
+  comments = {A comment},
+  keyword = {keyword1, keyword2}
+}

--- a/bibtexparser/tests/test_comments.py
+++ b/bibtexparser/tests/test_comments.py
@@ -50,6 +50,60 @@ Sunt in culpa qui officia deserunt mollit anim id est laborum.
                     "A comment"]
         self.assertEqual(bib.comments, expected)
 
+    def test_comments_percentage(self):
+        with open('bibtexparser/tests/data/comments_percentage.bib', 'r') as bibfile:
+            bib = BibTexParser(bibfile.read())
+            res = bib.get_entry_list()
+        expected = [{'ENTRYTYPE': 'article',
+                     'journal': 'Nice Journal',
+                     'volume': '12',
+                     'ID': 'Cesar2013',
+                     'year': '2013',
+                     'author': 'Jean Cesar',
+                     'comments': 'A comment',
+                     'keyword': 'keyword1, keyword2',
+                     'title': 'An amazing title'
+                     },
+                    {'ENTRYTYPE': 'article',
+                     'journal': 'Nice Journal',
+                     'volume': '12',
+                     'ID': 'Baltazar2013',
+                     'year': '2013',
+                     'author': 'Jean Baltazar',
+                     'comments': 'A comment',
+                     'keyword': 'keyword1, keyword2',
+                     'title': 'An amazing title'
+                     }]
+        self.assertEqual(res, expected)
+
+    @unittest.skip('Bug #45')
+    def test_comments_percentage_nocoma(self):
+        with open('bibtexparser/tests/data/comments_percentage_nolastcoma.bib', 'r') as bibfile:
+            bib = BibTexParser(bibfile.read())
+            res = bib.get_entry_list()
+        expected = [{'ENTRYTYPE': 'article',
+                     'journal': 'Nice Journal',
+                     'volume': '12',
+                     'ID': 'Cesar2013',
+                     'year': '2013',
+                     'author': 'Jean Cesar',
+                     'comments': 'A comment',
+                     'keyword': 'keyword1, keyword2',
+                     'title': 'An amazing title'
+                     },
+                    {'ENTRYTYPE': 'article',
+                     'journal': 'Nice Journal',
+                     'volume': '12',
+                     'ID': 'Baltazar2013',
+                     'year': '2013',
+                     'author': 'Jean Baltazar',
+                     'comments': 'A comment',
+                     'keyword': 'keyword1, keyword2',
+                     'title': 'An amazing title'
+                     }]
+        self.assertEqual(res, expected)
+
+
 
 class TestWriteComment(unittest.TestCase):
     def test_comment_write(self):


### PR DESCRIPTION
See #45 for a full discussion.

This branch integrates a test that reproduces the issue. The test is skipped and must be addressed.