### PR TITLE
place comma after indent for comma_first=True in bwriter

### DIFF
--- a/bibtexparser/bwriter.py
+++ b/bibtexparser/bwriter.py
@@ -92,7 +92,7 @@ class BibTexWriter(object):
         for field in [i for i in sorted(entry) if i not in ['ENTRYTYPE', 'ID']]:
             try:
                 if self.comma_first:
-                    bibtex += "\n," + self.indent + field + " = {" + entry[field] + "}"
+                    bibtex += "\n" + self.indent + ", " + field + " = {" + entry[field] + "}"
                 else:
                     bibtex += ",\n" + self.indent + field + " = {" + entry[field] + "}"
             except TypeError:

--- a/bibtexparser/tests/data/article_comma_first.bib
+++ b/bibtexparser/tests/data/article_comma_first.bib
@@ -1,11 +1,11 @@
 @ARTICLE{Cesar2013
-, author = {Jean Cesar}
-, title = {An amazing title}
-, year = {2013}
-, volume = {12}
-, journal = {Nice Journal}
-, comments = {A comment}
-, keyword = {keyword1, keyword2}
+ , author = {Jean Cesar}
+ , title = {An amazing title}
+ , year = {2013}
+ , volume = {12}
+ , journal = {Nice Journal}
+ , comments = {A comment}
+ , keyword = {keyword1, keyword2}
 }
 
 @ARTICLE{ Baltazar2013

--- a/bibtexparser/tests/data/book_comma_first.bib
+++ b/bibtexparser/tests/data/book_comma_first.bib
@@ -1,9 +1,9 @@
 @book{Bird1987
-,   author = {Bird, R.B. and Armstrong, R.C. and Hassager, O.}
-,   edition = {2}
-,   publisher = {Wiley Edition}
-,   title = {Dynamics of Polymeric Liquid}
-,   volume = {1}
-,   year = {1987}
+   , author = {Bird, R.B. and Armstrong, R.C. and Hassager, O.}
+   , edition = {2}
+   , publisher = {Wiley Edition}
+   , title = {Dynamics of Polymeric Liquid}
+   , volume = {1}
+   , year = {1987}
 }
 


### PR DESCRIPTION
changes:
```
@book{Bird1987
,   author = {Bird, R.B. and Armstrong, R.C. and Hassager, O.}
,   edition = {2}
,   publisher = {Wiley Edition}
,   title = {Dynamics of Polymeric Liquid}
,   volume = {1}
,   year = {1987}
}
```

to:
```
@book{Bird1987
   , author = {Bird, R.B. and Armstrong, R.C. and Hassager, O.}
   , edition = {2}
   , publisher = {Wiley Edition}
   , title = {Dynamics of Polymeric Liquid}
   , volume = {1}
   , year = {1987}
}
```

which preserves visual indentation.

edit: placed examples within code blocks