### PR TITLE
BUGFIX: @STRING records have a trailing '}' character

### DIFF
--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -224,7 +224,7 @@ class BibTexParser(object):
         # if a string record, put it in the replace_dict
         if record.lower().startswith('@string'):
             logger.debug('The record startswith @string')
-            key, val = [i.strip().strip('{').strip('}').replace('\n', ' ') for i in record.split('{', 1)[1].strip('\n').strip(',').strip('}').split('=')]
+            key, val = [i.strip().strip('{').strip('}').replace('\n', ' ') for i in record.split('{', 1)[1].strip('}').strip('\n').strip(',').split('=')]
             key = key.lower()  # key is case insensitive
             val = self._string_subst_partial(val)
             if val.startswith('"') or val.lower() not in self.bib_database.strings:


### PR DESCRIPTION
Hi,

Currently @STRING macro can have a trailing '}' character after parsing. For example:

```
@STRING{oakland = {Proceedings of the {IEEE} Symposium on Security and Privacy}}
@INPROCEEDINGS{cha:oakland15,
    author = {Sang Kil Cha and Maverick Woo and David Brumley},
    title = {{Program-Adaptive Mutational Fuzzing}},
    booktitle = oakland,
    year = {2015},
    pages = {725--741}
}
```
When we parse the above bibtex entry, the 'booktitle' field contains
**Proceedings of the {IEEE} Symposium on Security and Privacy},**
with extra '},'.

The root cause of this bug is due the wrong order of *strip* calls. This patch will fix this bug.

Best Regards,
Sang Kil