### PR TITLE
Allow dashes in field names

### DIFF
--- a/bibtexparser/bibtexexpression.py
+++ b/bibtexparser/bibtexexpression.py
@@ -142,7 +142,7 @@ class BibtexExpression(object):
         key.setParseAction(lambda s, l, t: first_token(s, l, t).strip())
 
         # Field name: word of letters and underscores
-        field_name = pp.Word(pp.alphas + '_')('FieldName')
+        field_name = pp.Word(pp.alphas + '_-')('FieldName')
         field_name.setParseAction(first_token)
 
         # Field: field_name = value


### PR DESCRIPTION
The `pyparsing` implementation brought some regressions. Dashes in field names seems pretty common, so they should probably be supported. Here is an example that breaks the parser:

```python
import bibtexparser

# bibtex entry from http://www.citeulike.org/bibtex_options/user/AlainDutech/article/7339123

bibtex_string = """@inproceedings{Singh2005,
    author = {Singh, Satinder and Barto, Andrew and Chentanez, Nuttapong},
    title = {Intrinsically Motivated Reinforcement Learning},
    year = {2005},
    citeulike-article-id = {7339123},
    posted-at = {2010-06-18 06:14:47},
    keyword = {dopamine, hierarchies, learning, motivation, options, reinforcement, semi_mdp},
    priority = {0},
    booktitle = {Proc. of the 18th Annual Conf. on Neural Information Processing Systems (NIPS'04)},
}"""

bib_database = bibtexparser.loads(bibtex_string)
```