### PR TITLE
Removes unused code for stripping braces and quotes.

### DIFF
--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -192,46 +192,6 @@ class BibTexParser(object):
             bibtex_str = bibtex_str.decode(encoding=self.encoding)
         return io.StringIO(bibtex_str)
 
-    def _strip_quotes(self, val):
-        """Strip double quotes enclosing string
-
-        :param val: a value
-        :type val: string
-        :returns: string -- value
-        """
-        logger.debug('Strip quotes')
-        val = val.strip()
-        if val.startswith('"') and val.endswith('"'):
-            return val[1:-1]
-        return val
-
-    def _strip_braces(self, val):
-        """Strip braces enclosing string
-
-        :param val: a value
-        :type val: string
-        :returns: string -- value
-        """
-        logger.debug('Strip braces')
-        val = val.strip()
-        if val.startswith('{') and val.endswith('}') and self._full_span(val):
-            return val[1:-1]
-        return val
-
-    def _full_span(self, val):
-        cnt = 0
-        for i in range(0, len(val)):
-                if val[i] == '{':
-                        cnt += 1
-                elif val[i] == '}':
-                        cnt -= 1
-                if cnt == 0:
-                        break
-        if i == len(val) - 1:
-                return True
-        else:
-                return False
-
     def _clean_val(self, val):
         """ Clean instring before adding to dictionary
 

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -50,44 +50,6 @@ def customizations_latex(record):
     return record
 
 
-class TestBibtexParserFunc(unittest.TestCase):
-    def test_strip_quotes(self):
-        parser = BibTexParser()
-        result = parser._strip_quotes('"before remove after"')
-        expected = 'before remove after'
-        self.assertEqual(result, expected)
-
-    def test_strip_quotes_n(self):
-        parser = BibTexParser()
-        result = parser._strip_quotes('"before remove after"\n')
-        expected = 'before remove after'
-        self.assertEqual(result, expected)
-
-    def test_strip_quotes2(self):
-        parser = BibTexParser()
-        result = parser._strip_quotes('before "remove" after')
-        expected = 'before "remove" after'
-        self.assertEqual(result, expected)
-
-    def test_strip_braces(self):
-        parser = BibTexParser()
-        result = parser._strip_braces('{before remove after}')
-        expected = 'before remove after'
-        self.assertEqual(result, expected)
-
-    def test_strip_braces2(self):
-        parser = BibTexParser()
-        result = parser._strip_braces('before {remove} after')
-        expected = 'before {remove} after'
-        self.assertEqual(result, expected)
-
-    def test_strip_braces_n(self):
-        parser = BibTexParser()
-        result = parser._strip_braces('{before remove after}\n')
-        expected = 'before remove after'
-        self.assertEqual(result, expected)
-
-
 class TestBibtexParserList(unittest.TestCase):
 
     def test_wrong(self):


### PR DESCRIPTION
This functionality is now directly handled by the parsing grammar.
Also removes the related tests.