### PR TITLE
Fixes test failure if title contains {\"u} et no outer { }

### DIFF
--- a/bibtexparser/bibtexexpression.py
+++ b/bibtexparser/bibtexexpression.py
@@ -112,13 +112,12 @@ class BibtexExpression(object):
         # TODO @ are not parsed by bibtex in braces
 
         # Quoted values: may contain braced content with balanced braces
-        brace_in_quoted = pp.nestedExpr('{', '}')
+        brace_in_quoted = pp.nestedExpr('{', '}', ignoreExpr=None)
         text_in_quoted = pp.CharsNotIn('"{}')
-        # (quotes should be escaped in quoted value)
+        # (quotes should be escaped by braces in quoted value)
         quoted_value = pp.originalTextFor(
-            '"' +
-            pp.ZeroOrMore(text_in_quoted | brace_in_quoted) +
-            '"')('QuotedValue')
+            '"' + pp.ZeroOrMore(text_in_quoted | brace_in_quoted) + '"'
+            )('QuotedValue')
         quoted_value.addParseAction(pp.removeQuotes)
 
         # String expressions

--- a/bibtexparser/tests/data/article_no_braces.bib
+++ b/bibtexparser/tests/data/article_no_braces.bib
@@ -1,5 +1,5 @@
 @ARTICLE{Cesar2013,
-  author = "Jean César",
+  author = "Jean C{\'e}sar{\"u}",
   title = "An amazing title",
   year = "2013",
   month = "jan",

--- a/bibtexparser/tests/data/article_with_special_characters.bib
+++ b/bibtexparser/tests/data/article_with_special_characters.bib
@@ -1,0 +1,13 @@
+@ARTICLE{Cesar2013,
+  author = {Jean C{\'e}sar{\"u}},
+  title = {An amazing title},
+  year = {2013},
+  month = "jan",
+  volume = {12},
+  pages = {12-23},
+  journal = {Nice Journal},
+  abstract = {This is an abstract. This line should be long enough to test
+multilines... and with a french érudit word},
+  comments = {A comment},
+  keyword = {keyword1, keyword2},
+}

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -272,7 +272,27 @@ class TestBibtexParserList(unittest.TestCase):
                      'ID': 'Cesar2013',
                      'year': '2013',
                      'month': 'jan',
-                     'author': 'Jean César',
+                     'author': 'Jean C{\\\'e}sar{\\\"u}',
+                     'comments': 'A comment',
+                     'keyword': 'keyword1, keyword2',
+                     'title': 'An amazing title',
+                     'abstract': "This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word",
+                     },
+                     ]
+        self.assertEqual(res, expected)
+
+    def test_article_special_characters(self):
+        with open('bibtexparser/tests/data/article_with_special_characters.bib', 'r') as bibfile:
+            bib = BibTexParser(bibfile.read())
+            res = bib.get_entry_list()
+        expected = [{'ENTRYTYPE': 'article',
+                     'journal': 'Nice Journal',
+                     'volume': '12',
+                     'pages': '12-23',
+                     'ID': 'Cesar2013',
+                     'year': '2013',
+                     'month': 'jan',
+                     'author': 'Jean C{\\\'e}sar{\\\"u}',
                      'comments': 'A comment',
                      'keyword': 'keyword1, keyword2',
                      'title': 'An amazing title',


### PR DESCRIPTION
See  #117 and #118.