### PR TITLE
Add customization.splitname() function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ nosetests.xml
 
 # Pycharm
 .idea
+
+# Vim.
+*.swp

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -33,3 +33,6 @@
 
 - Olivier Mangin
   Pyparsing implementation of the parser.
+
+- Blair Bonnett
+  customization.splitname() function

--- a/bibtexparser/customization.py
+++ b/bibtexparser/customization.py
@@ -15,9 +15,288 @@ from bibtexparser.latexenc import unicode_to_latex, unicode_to_crappy_latex1, un
 
 logger = logging.getLogger(__name__)
 
-__all__ = ['getnames', 'author', 'editor', 'journal', 'keyword', 'link',
-           'page_double_hyphen', 'doi', 'type', 'convert_to_unicode',
+__all__ = ['splitname', 'getnames', 'author', 'editor', 'journal', 'keyword',
+           'link', 'page_double_hyphen', 'doi', 'type', 'convert_to_unicode',
            'homogenize_latex_encoding']
+
+
+class InvalidName(ValueError):
+    """Exception raised by :py:func:`customization.splitname` when an invalid name is input.
+
+    """
+    pass
+
+
+def splitname(name, strict_mode=True):
+    """
+    Break a name into its constituent parts: First, von, Last, and Jr.
+
+    :param string name: a string containing a single name
+    :param Boolean strict_mode: whether to use strict mode
+    :returns: dictionary of constituent parts
+    :raises `customization.InvalidName`: If an invalid name is given and
+                                         ``strict_mode = True``.
+
+    In BibTeX, a name can be represented in any of three forms:
+        * First von Last
+        * von Last, First
+        * von Last, Jr, First
+
+    This function attempts to split a given name into its four parts. The
+    returned dictionary has keys of ``first``, ``last``, ``von`` and ``jr``.
+    Each value is a list of the words making up that part; this may be an empty
+    list.  If the input has no non-whitespace characters, a blank dictionary is
+    returned.
+
+    It is capable of detecting some errors with the input name. If the
+    ``strict_mode`` parameter is ``True``, which is the default, this results in
+    a :class:`customization.InvalidName` exception being raised. If it is
+    ``False``, the function continues, working around the error as best it can.
+    The errors that can be detected are listed below along with the handling
+    for non-strict mode:
+
+        * Name finishes with a trailing comma: delete the comma
+        * Too many parts (e.g., von Last, Jr, First, Error): merge extra parts
+          into First
+        * Unterminated opening brace: add closing brace to end of input
+        * Unmatched closing brace: add opening brace at start of word
+
+    """
+    # Useful references:
+    # http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html#names
+    # http://tug.ctan.org/info/bibtex/tamethebeast/ttb_en.pdf
+
+    # Whitespace characters that can separate words.
+    whitespace = set(' ~\r\n\t')
+
+    # We'll iterate over the input once, dividing it into a list of words for
+    # each comma-separated section. We'll also calculate the case of each word
+    # as we work.
+    sections = [[]]      # Sections of the name.
+    cases = [[]]         # 1 = uppercase, 0 = lowercase, -1 = caseless.
+    word = []            # Current word.
+    case = -1            # Case of the current word.
+    level = 0            # Current brace level.
+    bracestart = False   # Will the next character be the first within a brace?
+    controlseq = True    # Are we currently processing a control sequence?
+    specialchar = None   # Are we currently processing a special character?
+
+    # Using an iterator allows us to deal with escapes in a simple manner.
+    nameiter = iter(name)
+    for char in nameiter:
+        # An escape.
+        if char == '\\':
+            escaped = next(nameiter)
+
+            # BibTeX doesn't allow whitespace escaping. Copy the slash and fall
+            # through to the normal case to handle the whitespace.
+            if escaped in whitespace:
+                word.append(char)
+                char = escaped
+
+            else:
+                # Is this the first character in a brace?
+                if bracestart:
+                    bracestart = False
+                    controlseq = escaped.isalpha()
+                    specialchar = True
+
+                # Can we use it to determine the case?
+                elif (case == -1) and escaped.isalpha():
+                    if escaped.isupper():
+                        case = 1
+                    else:
+                        case = 0
+
+                # Copy the escape to the current word and go to the next
+                # character in the input.
+                word.append(char)
+                word.append(escaped)
+                continue
+
+        # Start of a braced expression.
+        if char == '{':
+            level += 1
+            word.append(char)
+            bracestart = True
+            controlseq = False
+            specialchar = False
+            continue
+
+        # All the below cases imply this (and don't test its previous value).
+        bracestart = False
+
+        # End of a braced expression.
+        if char == '}':
+            # Check and reduce the level.
+            if level:
+                level -= 1
+            else:
+                if strict_mode:
+                    raise InvalidName("Unmatched closing brace in name {{{0}}}.".format(name))
+                word.insert(0, '{')
+
+            # Update the state, append the character, and move on.
+            controlseq = False
+            specialchar = False
+            word.append(char)
+            continue
+
+        # Inside a braced expression.
+        if level:
+            # Is this the end of a control sequence?
+            if controlseq:
+                if not char.isalpha():
+                    controlseq = False
+
+            # If it's a special character, can we use it for a case?
+            elif specialchar:
+                if (case == -1) and char.isalpha():
+                    if char.isupper():
+                        case = 1
+                    else:
+                        case = 0
+
+            # Append the character and move on.
+            word.append(char)
+            continue
+
+        # End of a word.
+        # NB. we know we're not in a brace here due to the previous case.
+        if char == ',' or char in whitespace:
+            # Don't add empty words due to repeated whitespace.
+            if word:
+                sections[-1].append(''.join(word))
+                word = []
+                cases[-1].append(case)
+                case = -1
+                controlseq = False
+                specialchar = False
+
+            # End of a section.
+            if char == ',':
+                if len(sections) < 3:
+                    sections.append([])
+                    cases.append([])
+                elif strict_mode:
+                    raise InvalidName("Too many commas in the name {{{0}}}.".format(name))
+            continue
+
+        # Regular character.
+        word.append(char)
+        if (case == -1) and char.isalpha():
+            if char.isupper():
+                case = 1
+            else:
+                case = 0
+
+    # Unterminated brace?
+    if level:
+        if strict_mode:
+            raise InvalidName("Unterminated opening brace in the name {{{0}}}.".format(name))
+        while level:
+            word.append('}')
+            level -= 1
+
+    # Handle the final word.
+    if word:
+        sections[-1].append(''.join(word))
+        cases[-1].append(case)
+
+    # Get rid of trailing sections.
+    if not sections[-1]:
+        # Trailing comma?
+        if (len(sections) > 1) and strict_mode:
+            raise InvalidName("Trailing comma at end of name {{{0}}}.".format(name))
+        sections.pop(-1)
+        cases.pop(-1)
+
+    # No non-whitespace input.
+    if not sections or not any(bool(section) for section in sections):
+        return {}
+
+    # Initialise the output dictionary.
+    parts = {'first': [], 'last': [], 'von': [], 'jr': []}
+
+    # Form 1: "First von Last"
+    if len(sections) == 1:
+        p0 = sections[0]
+
+        # One word only: last cannot be empty.
+        if len(p0) == 1:
+            parts['last'] = p0
+
+        # Two words: must be first and last.
+        elif len(p0) == 2:
+            parts['first'] = p0[:1]
+            parts['last'] = p0[1:]
+
+        # Need to use the cases to figure it out.
+        else:
+            cases = cases[0]
+
+            # First is the longest sequence of words starting with uppercase
+            # that is not the whole string. von is then the longest sequence
+            # whose last word starts with lowercase that is not the whole
+            # string. Last is the rest. NB., this means last cannot be empty.
+
+            # At least one lowercase letter.
+            if 0 in cases:
+                # Index from end of list of first and last lowercase word.
+                firstl = cases.index(0) - len(cases)
+                lastl = -cases[::-1].index(0) - 1
+                if lastl == -1:
+                    lastl -= 1      # Cannot consume the rest of the string.
+
+                # Pull the parts out.
+                parts['first'] = p0[:firstl]
+                parts['von'] = p0[firstl:lastl+1]
+                parts['last'] = p0[lastl+1:]
+
+            # No lowercase: last is the last word, first is everything else.
+            else:
+                parts['first'] = p0[:-1]
+                parts['last'] = p0[-1:]
+
+    # Form 2 ("von Last, First") or 3 ("von Last, jr, First")
+    else:
+        # As long as there is content in the first name partition, use it as-is.
+        first = sections[-1]
+        if first and first[0]:
+            parts['first'] = first
+
+        # And again with the jr part.
+        if len(sections) == 3:
+            jr = sections[-2]
+            if jr and jr[0]:
+                parts['jr'] = jr
+
+        # Last name cannot be empty; if there is only one word in the first
+        # partition, we have to use it for the last name.
+        last = sections[0]
+        if len(last) == 1:
+            parts['last'] = last
+
+        # Have to look at the cases to figure it out.
+        else:
+            lcases = cases[0]
+
+            # At least one lowercase: von is the longest sequence of whitespace
+            # separated words whose last word does not start with an uppercase
+            # word, and last is the rest.
+            if 0 in lcases:
+                split = len(lcases) - lcases[::-1].index(0)
+                if split == len(lcases):
+                    split = 0            # Last cannot be empty.
+                parts['von'] = sections[0][:split]
+                parts['last'] = sections[0][split:]
+
+            # All uppercase => all last.
+            else:
+                parts['last'] = sections[0]
+
+    # Done.
+    return parts
 
 
 def getnames(names):

--- a/bibtexparser/tests/test_splitname.py
+++ b/bibtexparser/tests/test_splitname.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from bibtexparser.customization import InvalidName, splitname
+
+class TestSplitnameMethod(unittest.TestCase):
+    def test_splitname_basic(self):
+        """Basic tests of customization.splitname() """
+        # Empty input.
+        result = splitname("")
+        expected = {}
+        self.assertEqual(result, expected, msg="Invalid output for empty name")
+
+        # Non-whitespace names.
+        result = splitname("    ")
+        expected = {}
+        self.assertEqual(result, expected, msg="Invalid output for space-only name")
+        result = splitname("  \t~~")
+        expected = {}
+        self.assertEqual(result, expected, msg="Invalid output for whitespace name")
+
+        # Test strict mode.
+        with self.assertRaises(InvalidName):         # Trailing comma (4 cases).
+            splitname("BB,", strict_mode=True)
+        with self.assertRaises(InvalidName):
+            splitname("BB,  ", strict_mode=True)
+        with self.assertRaises(InvalidName):
+            splitname("BB, ~\t", strict_mode=True)
+        with self.assertRaises(InvalidName):
+            splitname(", ~\t", strict_mode=True)
+        with self.assertRaises(InvalidName):         # Too many sections.
+            splitname("AA, BB, CC, DD", strict_mode=True)
+        with self.assertRaises(InvalidName):         # Unterminated opening brace (x3).
+            splitname("AA {BB CC", strict_mode=True)
+        with self.assertRaises(InvalidName):
+            splitname("AA {{{BB CC", strict_mode=True)
+        with self.assertRaises(InvalidName):
+            splitname("AA {{{BB} CC}", strict_mode=True)
+        with self.assertRaises(InvalidName):         # Unmatched closing brace (x3).
+            splitname("AA BB CC}", strict_mode=True)
+        with self.assertRaises(InvalidName):
+            splitname("AA BB CC}}}", strict_mode=True)
+        with self.assertRaises(InvalidName):
+            splitname("{AA {BB CC}}}", strict_mode=True)
+
+        # Test strict mode off for trailing comma.
+        expected = {'first': [], 'von': [], 'last': ["BB"], 'jr': []}
+        result = splitname("BB,", strict_mode=False)
+        self.assertEqual(result, expected, msg="Invalid output for trailing comma with strict mode off")
+        result = splitname("BB,   ", strict_mode=False)
+        self.assertEqual(result, expected, msg="Invalid output for trailing comma with strict mode off")
+        result = splitname("BB,  ~\t ", strict_mode=False)
+        self.assertEqual(result, expected, msg="Invalid output for trailing comma with strict mode off")
+        expected = {}
+        result = splitname(",  ~\t", strict_mode=False)
+        self.assertEqual(result, expected, msg="Invalid output for trailing comma with strict mode off")
+
+        # Test strict mode off for too many sections.
+        expected = {'first': ["CC", "DD"], 'von': [], 'last': ["AA"], 'jr': ["BB"]}
+        result = splitname("AA, BB, CC, DD", strict_mode=False)
+        self.assertEqual(result, expected, msg="Invalid output for too many sections with strict mode off")
+
+        # Test strict mode off for an unterminated opening brace.
+        result = splitname("AA {BB CC", strict_mode=False)
+        expected = {'first': ["AA"], 'von': [], 'last': ["{BB CC}"], 'jr': []}
+        self.assertEqual(result, expected, msg="Invalid output for unterminated opening brace with strict mode off")
+        result = splitname("AA {{{BB CC", strict_mode=False)
+        expected = {'first': ["AA"], 'von': [], 'last': ["{{{BB CC}}}"], 'jr': []}
+        self.assertEqual(result, expected, msg="Invalid output for unterminated opening brace with strict mode off")
+        result = splitname("AA {{{BB} CC}", strict_mode=False)
+        expected = {'first': ["AA"], 'von': [], 'last': ["{{{BB} CC}}"], 'jr': []}
+        self.assertEqual(result, expected, msg="Invalid output for unterminated opening brace with strict mode off")
+
+        # Test strict mode off for an unmatched closing brace.
+        result = splitname("AA BB CC}", strict_mode=False)
+        expected = {'first': ["AA", "BB"], 'von': [], 'last': ["{CC}"], 'jr': []}
+        self.assertEqual(result, expected, msg="Invalid output for unmatched closing brace with strict mode off")
+        result = splitname("AA BB CC}}}", strict_mode=False)
+        expected = {'first': ["AA", "BB"], 'von': [], 'last': ["{{{CC}}}"], 'jr': []}
+        self.assertEqual(result, expected, msg="Invalid output for unmatched closing brace with strict mode off")
+        result = splitname("{AA {BB CC}}}", strict_mode=False)
+        expected = {'first': [], 'von': [], 'last': ["{{AA {BB CC}}}"], 'jr': []}
+        self.assertEqual(result, expected, msg="Invalid output for unmatched closing brace with strict mode off")
+
+        # Test it handles commas at higher brace levels.
+        result = splitname("CC, dd, {AA, BB}")
+        expected = {'first': ["{AA, BB}"], 'von': [], 'last': ["CC"], 'jr': ["dd"]}
+        self.assertEqual(result, expected, msg="Invalid output for braced commas")
+
+
+    def test_splitname_cases(self):
+        """Test customization.splitname() vs output from BibTeX """
+        for name, expected in splitname_test_cases:
+            result = splitname(name)
+            self.assertEqual(result, expected, msg="Input name: {0}".format(name))
+
+
+splitname_test_cases = (
+    (r'Per Brinch Hansen',
+     {'first': ['Per', 'Brinch'], 'von': [], 'last': ['Hansen'], 'jr': []}),
+
+    (r'Brinch Hansen, Per',
+     {'first': ['Per'], 'von': [], 'last': ['Brinch', 'Hansen'], 'jr': []}),
+
+    (r'Brinch Hansen,, Per',
+     {'first': ['Per'], 'von': [], 'last': ['Brinch', 'Hansen'], 'jr': []}),
+
+    (r"Charles Louis Xavier Joseph de la Vall{\'e}e Poussin",
+     {'first': ['Charles', 'Louis', 'Xavier', 'Joseph'], 'von': ['de', 'la'],
+      'last':  [r'Vall{\'e}e', 'Poussin'], 'jr': []}),
+
+    (r'D[onald] E. Knuth',
+     {'first': ['D[onald]', 'E.'], 'von': [], 'last': ['Knuth'], 'jr': []}),
+
+    (r'A. {Delgado de Molina}',
+     {'first': ['A.'], 'von': [], 'last': ['{Delgado de Molina}'], 'jr': []}),
+
+    (r"M. Vign{\'e}",
+     {'first': ['M.'], 'von': [], 'last': [r"Vign{\'e}"], 'jr': []}),
+
+###############################################################################
+#
+# Test cases from
+# http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html
+#
+###############################################################################
+
+    (r'AA BB',
+     {'first': ['AA'], 'von': [], 'last': ['BB'], 'jr': []}),
+
+    (r'AA',
+     {'first': [], 'von': [], 'last': ['AA'], 'jr': []}),
+
+    (r'AA bb',
+     {'first': ['AA'], 'von': [], 'last': ['bb'], 'jr': []}),
+
+    (r'aa',
+     {'first': [], 'von': [], 'last': ['aa'], 'jr': []}),
+
+    (r'AA bb CC',
+     {'first': ['AA'], 'von': ['bb'], 'last': ['CC'], 'jr': []}),
+
+    (r'AA bb CC dd EE',
+     {'first': ['AA'], 'von': ['bb', 'CC', 'dd'], 'last': ['EE'], 'jr': []}),
+
+    (r'AA 1B cc dd',
+     {'first': ['AA', '1B'], 'von': ['cc'], 'last': ['dd'], 'jr': []}),
+
+    (r'AA 1b cc dd',
+     {'first': ['AA'], 'von': ['1b', 'cc'], 'last': ['dd'], 'jr': []}),
+
+    (r'AA {b}B cc dd',
+     {'first': ['AA', '{b}B'], 'von': ['cc'], 'last': ['dd'], 'jr': []}),
+
+    (r'AA {b}b cc dd',
+     {'first': ['AA'], 'von': ['{b}b', 'cc'], 'last': ['dd'], 'jr': []}),
+
+    (r'AA {B}b cc dd',
+     {'first': ['AA'], 'von': ['{B}b', 'cc'], 'last': ['dd'], 'jr': []}),
+
+    (r'AA {B}B cc dd',
+     {'first': ['AA', '{B}B'], 'von': ['cc'], 'last': ['dd'], 'jr': []}),
+
+    (r'AA \BB{b} cc dd',
+     {'first': ['AA', r'\BB{b}'], 'von': ['cc'], 'last': ['dd'], 'jr': []}),
+
+    (r'AA \bb{b} cc dd',
+     {'first': ['AA'], 'von': [r'\bb{b}', 'cc'], 'last': ['dd'], 'jr': []}),
+
+    (r'AA {bb} cc DD',
+     {'first': ['AA', '{bb}'], 'von': ['cc'], 'last': ['DD'], 'jr': []}),
+
+    (r'AA bb {cc} DD',
+     {'first': ['AA'], 'von': ['bb'], 'last': ['{cc}', 'DD'], 'jr': []}),
+
+    (r'AA {bb} CC',
+     {'first': ['AA', '{bb}'], 'von': [], 'last': ['CC'], 'jr': []}),
+
+    (r'bb CC, AA',
+     {'first': ['AA'], 'von': ['bb'], 'last': ['CC'], 'jr': []}),
+
+    (r'bb CC, aa',
+     {'first': ['aa'], 'von': ['bb'], 'last': ['CC'], 'jr': []}),
+
+    (r'bb CC dd EE, AA',
+     {'first': ['AA'], 'von': ['bb', 'CC', 'dd'], 'last': ['EE'], 'jr': []}),
+
+    (r'bb, AA',
+     {'first': ['AA'], 'von': [], 'last': ['bb'], 'jr': []}),
+
+    (r'bb CC,XX, AA',
+     {'first': ['AA'], 'von': ['bb'], 'last': ['CC'], 'jr': ['XX']}),
+
+    (r'bb CC,xx, AA',
+     {'first': ['AA'], 'von': ['bb'], 'last': ['CC'], 'jr': ['xx']}),
+
+    (r'BB,, AA',
+     {'first': ['AA'], 'von': [], 'last': ['BB'], 'jr': []}),
+
+    (r"Paul \'Emile Victor",
+     {'first': ['Paul', r"\'Emile"], 'von': [], 'last': ['Victor'], 'jr': []}),
+
+    (r"Paul {\'E}mile Victor",
+     {'first': ['Paul', r"{\'E}mile"], 'von': [], 'last': ['Victor'], 'jr': []}),
+
+    (r"Paul \'emile Victor",
+     {'first': ['Paul'], 'von': [r"\'emile"], 'last': ['Victor'], 'jr': []}),
+
+    (r"Paul {\'e}mile Victor",
+     {'first': ['Paul'], 'von': [r"{\'e}mile"], 'last': ['Victor'], 'jr': []}),
+
+    (r"Victor, Paul \'Emile",
+     {'first': ['Paul', r"\'Emile"], 'von': [], 'last': ['Victor'], 'jr': []}),
+
+    (r"Victor, Paul {\'E}mile",
+     {'first': ['Paul', r"{\'E}mile"], 'von': [], 'last': ['Victor'], 'jr': []}),
+
+    (r"Victor, Paul \'emile",
+     {'first': ['Paul', r"\'emile"], 'von': [], 'last': ['Victor'], 'jr': []}),
+
+    (r"Victor, Paul {\'e}mile",
+     {'first': ['Paul', r"{\'e}mile"], 'von': [], 'last': ['Victor'], 'jr': []}),
+
+    (r'Dominique Galouzeau de Villepin',
+     {'first': ['Dominique', 'Galouzeau'], 'von': ['de'], 'last': ['Villepin'], 'jr': []}),
+
+    (r'Dominique {G}alouzeau de Villepin',
+     {'first': ['Dominique'], 'von': ['{G}alouzeau', 'de'],
+      'last': ['Villepin'], 'jr': []}),
+
+    (r'Galouzeau de Villepin, Dominique',
+     {'first': ['Dominique'], 'von': ['Galouzeau', 'de'],
+      'last': ['Villepin'], 'jr': []}),
+
+###############################################################################
+#
+# Test cases from pybtex
+# See file /pybtex/tests/parse_name_test.py in the pybtex source.
+#
+###############################################################################
+
+    (r'A. E.                   Siegman',
+     {'first': ['A.', 'E.'], 'von': [], 'last': ['Siegman'], 'jr': []}),
+
+    (r'A. G. W. Cameron',
+     {'first': ['A.', 'G.', 'W.'], 'von': [], 'last': ['Cameron'], 'jr': []}),
+
+    (r'A. Hoenig',
+     {'first': ['A.'], 'von': [], 'last': ['Hoenig'], 'jr': []}),
+
+    (r'A. J. Van Haagen',
+     {'first': ['A.', 'J.', 'Van'], 'von': [], 'last': ['Haagen'], 'jr': []}),
+
+    (r'A. S. Berdnikov',
+     {'first': ['A.', 'S.'], 'von': [], 'last': ['Berdnikov'], 'jr': []}),
+
+    (r'A. Trevorrow',
+     {'first': ['A.'], 'von': [], 'last': ['Trevorrow'], 'jr': []}),
+
+    (r'Adam H. Lewenberg',
+     {'first': ['Adam', 'H.'], 'von': [], 'last': ['Lewenberg'], 'jr': []}),
+
+    (r'Addison-Wesley Publishing Company',
+     {'first': ['Addison-Wesley', 'Publishing'], 'von': [],
+      'last': ['Company'], 'jr': []}),
+
+    (r'Advogato (Raph Levien)',
+     {'first': ['Advogato', '(Raph'], 'von': [], 'last': ['Levien)'], 'jr': []}),
+
+    (r'Andrea de Leeuw van Weenen',
+     {'first': ['Andrea'], 'von': ['de', 'Leeuw', 'van'], 'last': ['Weenen'], 'jr': []}),
+
+    (r'Andreas Geyer-Schulz',
+     {'first': ['Andreas'], 'von': [], 'last': ['Geyer-Schulz'], 'jr': []}),
+
+    (r'Andr{\'e} Heck',
+     {'first': [r'Andr{\'e}'], 'von': [], 'last': ['Heck'], 'jr': []}),
+
+    (r'Anne Br{\"u}ggemann-Klein',
+     {'first': ['Anne'], 'von': [], 'last': [r'Br{\"u}ggemann-Klein'], 'jr': []}),
+
+    (r'Anonymous',
+     {'first': [], 'von': [], 'last': ['Anonymous'], 'jr': []}),
+
+    (r'B. Beeton',
+     {'first': ['B.'], 'von': [], 'last': ['Beeton'], 'jr': []}),
+
+    (r'B. Hamilton Kelly',
+     {'first': ['B.', 'Hamilton'], 'von': [], 'last': ['Kelly'], 'jr': []}),
+
+    (r'B. V. Venkata Krishna Sastry',
+     {'first': ['B.', 'V.', 'Venkata', 'Krishna'], 'von': [],
+      'last': ['Sastry'], 'jr': []}),
+
+    (r'Benedict L{\o}fstedt',
+     {'first': ['Benedict'], 'von': [], 'last': [r'L{\o}fstedt'], 'jr': []}),
+
+    (r'Bogus{\l}aw Jackowski',
+     {'first': ['Bogus{\l}aw'], 'von': [], 'last': ['Jackowski'], 'jr': []}),
+
+    (r'Christina A. L.\ Thiele',
+     {'first': ['Christina', 'A.', 'L.\\'], 'von': [],
+      'last': ['Thiele'], 'jr': []}),
+
+    (r"D. Men'shikov",
+     {'first': ['D.'], 'von': [], 'last': ["Men'shikov"], 'jr': []}),
+
+    (r'Darko \v{Z}ubrini{\'c}',
+     {'first': ['Darko'], 'von': [], 'last': [r'\v{Z}ubrini{\'c}'], 'jr': []}),
+
+    (r'Dunja Mladeni{\'c}',
+     {'first': ['Dunja'], 'von': [], 'last': [r'Mladeni{\'c}'], 'jr': []}),
+
+    (r'Edwin V. {Bell, II}',
+     {'first': ['Edwin', 'V.'], 'von': [], 'last': ['{Bell, II}'], 'jr': []}),
+
+    (r'Frank G. {Bennett, Jr.}',
+     {'first': ['Frank', 'G.'], 'von': [], 'last': ['{Bennett, Jr.}'], 'jr': []}),
+
+    (r'Fr{\'e}d{\'e}ric Boulanger',
+     {'first': [r'Fr{\'e}d{\'e}ric'], 'von': [], 'last': ['Boulanger'], 'jr': []}),
+
+    (r'Ford, Jr., Henry',
+     {'first': ['Henry'], 'von': [], 'last': ['Ford'], 'jr': ['Jr.']}),
+
+    (r'mr Ford, Jr., Henry',
+     {'first': ['Henry'], 'von': ['mr'], 'last': ['Ford'], 'jr': ['Jr.']}),
+
+    (r'Fukui Rei',
+     {'first': ['Fukui'], 'von': [], 'last': ['Rei'], 'jr': []}),
+
+    (r'G. Gr{\"a}tzer',
+     {'first': ['G.'], 'von': [], 'last': [r'Gr{\"a}tzer'], 'jr': []}),
+
+    (r'George Gr{\"a}tzer',
+     {'first': ['George'], 'von': [], 'last': [r'Gr{\"a}tzer'], 'jr': []}),
+
+    (r'Georgia K. M. Tobin',
+     {'first': ['Georgia', 'K.', 'M.'], 'von': [], 'last': ['Tobin'], 'jr': []}),
+
+    (r'Gilbert van den Dobbelsteen',
+     {'first': ['Gilbert'], 'von': ['van', 'den'], 'last': ['Dobbelsteen'], 'jr': []}),
+
+    (r'Gy{\"o}ngyi Bujdos{\'o}',
+     {'first': [r'Gy{\"o}ngyi'], 'von': [], 'last': [r'Bujdos{\'o}'], 'jr': []}),
+
+    (r'Helmut J{\"u}rgensen',
+     {'first': ['Helmut'], 'von': [], 'last': [r'J{\"u}rgensen'], 'jr': []}),
+
+    (r'Herbert Vo{\ss}',
+     {'first': ['Herbert'], 'von': [], 'last': ['Vo{\ss}'], 'jr': []}),
+
+    (r"H{\'a}n Th{\^e}\llap{\raise 0.5ex\hbox{\'{\relax}}} Th{\'a}nh",
+     {'first': [r'H{\'a}n', r"Th{\^e}\llap{\raise 0.5ex\hbox{\'{\relax}}}"],
+      'von': [], 'last': [r"Th{\'a}nh"], 'jr': []}),
+
+    (r"H{\`a}n Th\^e\llap{\raise0.5ex\hbox{\'{\relax}}} Th{\`a}nh",
+     {'first': [r'H{\`a}n', r"Th\^e\llap{\raise0.5ex\hbox{\'{\relax}}}"],
+      'von': [], 'last': [r"Th{\`a}nh"], 'jr': []}),
+
+    (r'J. Vesel{\'y}',
+     {'first': ['J.'], 'von': [], 'last': [r'Vesel{\'y}'], 'jr': []}),
+
+    (r'Javier Rodr\'{\i}guez Laguna',
+     {'first': ['Javier', r'Rodr\'{\i}guez'], 'von': [], 'last': ['Laguna'], 'jr': []}),
+
+    (r'Ji\v{r}\'{\i} Vesel{\'y}',
+     {'first': [r'Ji\v{r}\'{\i}'], 'von': [], 'last': [r'Vesel{\'y}'], 'jr': []}),
+
+    (r'Ji\v{r}\'{\i} Zlatu{\v{s}}ka',
+     {'first': [r'Ji\v{r}\'{\i}'], 'von': [], 'last': [r'Zlatu{\v{s}}ka'], 'jr': []}),
+
+    (r'Ji\v{r}{\'\i} Vesel{\'y}',
+     {'first': [r'Ji\v{r}{\'\i}'], 'von': [], 'last': [r'Vesel{\'y}'], 'jr': []}),
+
+    (r'Ji\v{r}{\'{\i}}Zlatu{\v{s}}ka',
+     {'first': [], 'von': [], 'last': [r'Ji\v{r}{\'{\i}}Zlatu{\v{s}}ka'], 'jr': []}),
+
+    (r'Jim Hef{}feron',
+     {'first': ['Jim'], 'von': [], 'last': ['Hef{}feron'], 'jr': []}),
+
+    (r'J{\"o}rg Knappen',
+     {'first': [r'J{\"o}rg'], 'von': [], 'last': ['Knappen'], 'jr': []}),
+
+    (r'J{\"o}rgen L. Pind',
+     {'first': [r'J{\"o}rgen', 'L.'], 'von': [], 'last': ['Pind'], 'jr': []}),
+
+    (r'J{\'e}r\^ome Laurens',
+     {'first': [r'J{\'e}r\^ome'], 'von': [], 'last': ['Laurens'], 'jr': []}),
+
+    (r'J{{\"o}}rg Knappen',
+     {'first': [r'J{{\"o}}rg'], 'von': [], 'last': ['Knappen'], 'jr': []}),
+
+    (r'K. Anil Kumar',
+     {'first': ['K.', 'Anil'], 'von': [], 'last': ['Kumar'], 'jr': []}),
+
+    (r'Karel Hor{\'a}k',
+     {'first': ['Karel'], 'von': [], 'last': [r'Hor{\'a}k'], 'jr': []}),
+
+    (r'Karel P\'{\i}{\v{s}}ka',
+     {'first': ['Karel'], 'von': [], 'last': [r'P\'{\i}{\v{s}}ka'], 'jr': []}),
+
+    (r'Karel P{\'\i}{\v{s}}ka',
+     {'first': ['Karel'], 'von': [], 'last': [r'P{\'\i}{\v{s}}ka'], 'jr': []}),
+
+    (r'Karel Skoup\'{y}',
+     {'first': ['Karel'], 'von': [], 'last': [r'Skoup\'{y}'], 'jr': []}),
+
+    (r'Karel Skoup{\'y}',
+     {'first': ['Karel'], 'von': [], 'last': [r'Skoup{\'y}'], 'jr': []}),
+
+    (r'Kent McPherson',
+     {'first': ['Kent'], 'von': [], 'last': ['McPherson'], 'jr': []}),
+
+    (r'Klaus H{\"o}ppner',
+     {'first': ['Klaus'], 'von': [], 'last': [r'H{\"o}ppner'], 'jr': []}),
+
+    (r'Lars Hellstr{\"o}m',
+     {'first': ['Lars'], 'von': [], 'last': [r'Hellstr{\"o}m'], 'jr': []}),
+
+    (r'Laura Elizabeth Jackson',
+     {'first': ['Laura', 'Elizabeth'], 'von': [], 'last': ['Jackson'], 'jr': []}),
+
+    (r'M. D{\'{\i}}az',
+     {'first': ['M.'], 'von': [], 'last': [r'D{\'{\i}}az'], 'jr': []}),
+
+    (r'M/iche/al /O Searc/oid',
+     {'first': [r'M/iche/al', r'/O'], 'von': [], 'last': [r'Searc/oid'], 'jr': []}),
+
+    (r'Marek Ry{\'c}ko',
+     {'first': ['Marek'], 'von': [], 'last': [r'Ry{\'c}ko'], 'jr': []}),
+
+    (r'Marina Yu. Nikulina',
+     {'first': ['Marina', 'Yu.'], 'von': [], 'last': ['Nikulina'], 'jr': []}),
+
+    (r'Max D{\'{\i}}az',
+     {'first': ['Max'], 'von': [], 'last': [r'D{\'{\i}}az'], 'jr': []}),
+
+    (r'Merry Obrecht Sawdey',
+     {'first': ['Merry', 'Obrecht'], 'von': [], 'last': ['Sawdey'], 'jr': []}),
+
+    (r'Miroslava Mis{\'a}kov{\'a}',
+     {'first': ['Miroslava'], 'von': [], 'last': [r'Mis{\'a}kov{\'a}'], 'jr': []}),
+
+    (r'N. A. F. M. Poppelier',
+     {'first': ['N.', 'A.', 'F.', 'M.'], 'von': [], 'last': ['Poppelier'], 'jr': []}),
+
+    (r'Nico A. F. M. Poppelier',
+     {'first': ['Nico', 'A.', 'F.', 'M.'], 'von': [], 'last': ['Poppelier'], 'jr': []}),
+
+    (r'Onofrio de Bari',
+     {'first': ['Onofrio'], 'von': ['de'], 'last': ['Bari'], 'jr': []}),
+
+    (r'Pablo Rosell-Gonz{\'a}lez',
+     {'first': ['Pablo'], 'von': [], 'last': [r'Rosell-Gonz{\'a}lez'], 'jr': []}),
+
+    (r'Paco La                  Bruna',
+     {'first': ['Paco', 'La'], 'von': [], 'last': ['Bruna'], 'jr': []}),
+
+    (r'Paul                  Franchi-Zannettacci',
+     {'first': ['Paul'], 'von': [], 'last': ['Franchi-Zannettacci'], 'jr': []}),
+
+    (r'Pavel \v{S}eve\v{c}ek',
+     {'first': ['Pavel'], 'von': [], 'last': [r'\v{S}eve\v{c}ek'], 'jr': []}),
+
+    (r'Petr Ol{\v{s}}ak',
+     {'first': ['Petr'], 'von': [], 'last': [r'Ol{\v{s}}ak'], 'jr': []}),
+
+    (r'Petr Ol{\v{s}}{\'a}k',
+     {'first': ['Petr'], 'von': [], 'last': [r'Ol{\v{s}}{\'a}k'], 'jr': []}),
+
+    (r'Primo\v{z} Peterlin',
+     {'first': [r'Primo\v{z}'], 'von': [], 'last': ['Peterlin'], 'jr': []}),
+
+    (r'Prof. Alban Grimm',
+     {'first': ['Prof.', 'Alban'], 'von': [], 'last': ['Grimm'], 'jr': []}),
+
+    (r'P{\'e}ter Husz{\'a}r',
+     {'first': [r'P{\'e}ter'], 'von': [], 'last': [r'Husz{\'a}r'], 'jr': []}),
+
+    (r'P{\'e}ter Szab{\'o}',
+     {'first': [r'P{\'e}ter'], 'von': [], 'last': [r'Szab{\'o}'], 'jr': []}),
+
+    (r'Rafa{\l}\.Zbikowski',
+     {'first': [], 'von': [], 'last': [r'Rafa{\l}\.Zbikowski'], 'jr': []}),
+
+    (r'Rainer Sch{\"o}pf',
+     {'first': ['Rainer'], 'von': [], 'last': [r'Sch{\"o}pf'], 'jr': []}),
+
+    (r'T. L. (Frank) Pappas',
+     {'first': ['T.', 'L.', '(Frank)'], 'von': [], 'last': ['Pappas'], 'jr': []}),
+
+    (r'TUG 2004 conference',
+     {'first': ['TUG', '2004'], 'von': [], 'last': ['conference'], 'jr': []}),
+
+    (r'TUG {\sltt DVI} Driver Standards Committee',
+     {'first': ['TUG', '{\sltt DVI}', 'Driver', 'Standards'], 'von': [],
+      'last': ['Committee'], 'jr': []}),
+
+    (r'TUG {\sltt xDVIx} Driver Standards Committee',
+     {'first': ['TUG'], 'von': ['{\sltt xDVIx}'],
+      'last': ['Driver', 'Standards', 'Committee'], 'jr': []}),
+
+    (r'University of M{\"u}nster',
+     {'first': ['University'], 'von': ['of'], 'last': [r'M{\"u}nster'], 'jr': []}),
+
+    (r'Walter van der Laan',
+     {'first': ['Walter'], 'von': ['van', 'der'], 'last': ['Laan'], 'jr': []}),
+
+    (r'Wendy G.                  McKay',
+     {'first': ['Wendy', 'G.'], 'von': [], 'last': ['McKay'], 'jr': []}),
+
+    (r'Wendy McKay',
+     {'first': ['Wendy'], 'von': [], 'last': ['McKay'], 'jr': []}),
+
+    (r'W{\l}odek Bzyl',
+     {'first': [r'W{\l}odek'], 'von': [], 'last': ['Bzyl'], 'jr': []}),
+
+    (r'\LaTeX Project Team',
+     {'first': [r'\LaTeX', 'Project'], 'von': [], 'last': ['Team'], 'jr': []}),
+
+    (r'\rlap{Lutz Birkhahn}',
+     {'first': [], 'von': [], 'last': [r'\rlap{Lutz Birkhahn}'], 'jr': []}),
+
+    (r'{Jim Hef{}feron}',
+     {'first': [], 'von': [], 'last': ['{Jim Hef{}feron}'], 'jr': []}),
+
+    (r'{Kristoffer H\o{}gsbro Rose}',
+     {'first': [], 'von': [], 'last': ['{Kristoffer H\o{}gsbro Rose}'], 'jr': []}),
+
+    (r'{TUG} {Working} {Group} on a {\TeX} {Directory} {Structure}',
+     {'first': ['{TUG}', '{Working}', '{Group}'], 'von': ['on', 'a'],
+      'last': [r'{\TeX}', '{Directory}', '{Structure}'], 'jr': []}),
+
+    (r'{The \TUB{} Team}',
+     {'first': [], 'von': [], 'last': [r'{The \TUB{} Team}'], 'jr': []}),
+
+    (r'{\LaTeX} project team',
+     {'first': [r'{\LaTeX}'], 'von': ['project'], 'last': ['team'], 'jr': []}),
+
+    (r'{\NTG{} \TeX{} future working group}',
+     {'first': [], 'von': [], 'last': [r'{\NTG{} \TeX{} future working group}'], 'jr': []}),
+
+    (r'{{\LaTeX\,3} Project Team}',
+     {'first': [], 'von': [], 'last': [r'{{\LaTeX\,3} Project Team}'], 'jr': []}),
+
+    (r'Johansen Kyle, Derik Mamania M.',
+     {'first': ['Derik', 'Mamania', 'M.'], 'von': [], 'last': ['Johansen', 'Kyle'], 'jr': []}),
+
+    (r"Johannes Adam Ferdinand Alois Josef Maria Marko d'Aviano Pius von und zu Liechtenstein",
+     {'first': ['Johannes', 'Adam', 'Ferdinand', 'Alois', 'Josef', 'Maria', 'Marko'],
+      'von': ["d'Aviano", 'Pius', 'von', 'und', 'zu'], 'last': ['Liechtenstein'], 'jr': []}),
+
+    (r"Brand\~{a}o, F",
+     {'first': ['F'], 'von': [], 'last': ['Brand\\', '{a}o'], 'jr': []}),
+)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/source/bibtexparser.rst
+++ b/docs/source/bibtexparser.rst
@@ -29,6 +29,10 @@ bibtexparser: API
 .. automodule:: customization
     :members:
 
+Exception classes
+^^^^^^^^^^^^^^^^^
+.. autoclass:: customization.InvalidName
+
 :mod:`bibtexparser.bwriter` --- Tune the default writer
 -------------------------------------------------------
 


### PR DESCRIPTION
This pull request adds a `splitname()` function to the customization module. It takes a single name as a string, splits it up into the first / von / last / jr parts as per BibTeX, and returns a dictionary. Splitting the string into words is accomplished in a single pass over the string, and then the words are divided up into parts as per BibTeX. Basic error checking is performed while dividing it up into words, and can be suppressed and automatically corrected by setting the `strict_mode` parameter to False.

A large number of testcases are added. Many of these are taken from [Xavier Décoret's BibTeX reference page](http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html#names) and the [unit tests](https://bitbucket.org/pybtex-devs/pybtex/src/1819074df33ae76f95b370194caf858fa75c862c/pybtex/tests/parse_name_test.py?at=master&fileviewer=file-view-default) of the [Pybtex project](https://bitbucket.org/pybtex-devs/pybtex/src).

I'm not sure if the customization module is the best place for this function, or if you'd prefer to have it live in another module.

I have made no attempt to rewrite `customization.getnames()` to use this function yet; I decided to wait until this function was finalised before considering doing so. Another future possibility is to add a `format_name()` function to take the split-up pieces of a name and output them into a formatted string, doing things such as initialisation.

For me, the tests pass on both Python 2.7 and 3.5, and the `splitname()` docstring appears in the documentation.