### PR TITLE
Add author parsing code.

### DIFF
--- a/bibtexparser/author_parse.py
+++ b/bibtexparser/author_parse.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+
+
+"""
+This script merges a new bib file with an existing one.
+
+It is not very smart -- mostly what it does is give a "Chris Style" key.
+
+Then , with the merge it will make sure you don't have duplicate keys --
+but it will allow duplicate entries!
+
+We can make that smarter, later, but duplicates can be hard to identify!
+
+
+The "hard" part of this script is parsing the author string -- that's tricky!
+
+Using info from:
+
+http://nwalsh.com/tex/texhelp/bibtx-23.html
+
+and
+
+"The LaTeX companion"
+
+To figure out bibTeX author parsing
+
+The tests include all the examples in The LaTeX Companion (1993)
+
+NOTE: This would probably be more robust if it were re-written to do the tokenizing
+      directly in a TeX aware way i.e. handling {} and \commands{} exactly like TeX does.
+      But then it couldn't use python's nifty built-in string methods.
+"""
+
+import bibtexparser
+
+new_filename = "endnote_export.bib"
+main_filename = "gnome_references.bib"
+
+
+class Author():
+    """
+    Holds a Author object -- really just a few fields
+
+    Also contains code for parsing BiBTeX author strings
+    """
+    # using Unicode "Private use areas"
+    # these are used to replace spaces and commas inside {}
+    # so everyting within a bracket will be treated as one token
+    replace_space = "\uE000"  # "_"
+    replace_comma = "\uE001"  # "`"
+    replace_and = "\uE001"
+
+    def __init__(self, first='', von='', last='', jr=''):
+        self.first = first.strip()
+        self.von = von.strip()
+        self.last = last.strip()
+        self.jr = jr.strip()
+
+    def split_authors(self, author_str):
+        """
+        parses the complete author string to break up multiple authors
+
+        returns a list of authors: each author is a string
+        """
+        print(author_str)
+
+        # splitting on "and", but bracket aware:
+        brackets = 0
+        and_ind = []
+        for i, c in enumerate(author_str[:]):
+            if c == "{":
+                brackets += 1
+            elif c == "}":
+                brackets -= 1
+            elif not brackets:
+                if author_str[i:i + 3] == "and":
+                    and_ind.append(i)
+        print("and indexes:", and_ind)
+        authors = []
+        for i in and_ind:
+            print (author_str)
+            authors.append(author_str[:i].strip())
+            author_str = author_str[i + 3:]
+            print(authors, author_str)
+        authors.append(author_str.strip())
+        print(authors)
+
+        return authors
+
+    @staticmethod
+    def firstislower(s):
+        """
+        an islower() function that finds if th first letter is lower case,
+        ignoring TeX control sequences
+
+        used to find "von" parts of names
+        """
+        ind = 0
+        in_control = False
+        for c in s:
+            if c == "{":
+                ind += 1
+                in_control = False
+            elif c == "\\":
+                ind += 1
+                in_control = True
+            else:
+                if not in_control:
+                    return c.islower()
+        return False
+
+    @classmethod
+    def from_string(cls, string):
+        # raw string -- there is a \u in there!
+        r"""
+        create an author object from a BiBTex compatible string
+
+        Apparently there are three options for names:
+
+        "First von Last" "von Last, First" "von Last, Jr, First"
+
+        So I use the number of commas to figure out which this is
+
+        fixme: this doesn't handle {} correctly -- {} can be used
+               to group extra stuff an commas into one part of a name.
+
+               it also won't handle capitalization of von:
+               Maria {\uppercase{d}e La} Cruz
+               (the von should be "De La")
+
+        """
+        author = cls()  # so we can use instance methods
+        string = author.pre_processs_brackets(string)
+
+        first, von, last, jr = ('',) * 4
+        string = string.strip()
+        # if there is a comma, the first name is after the comma
+        if "," in string:
+            parts = string.rsplit(",", 1)
+            first = parts[1].strip()
+            string = parts[0].strip()
+
+            # now if there is still a comma, it's a Jr
+            print("first name removed:", first, repr(string))
+            parts = string.partition(",")
+            jr = parts[2]
+            string = parts[0]
+            print("Jr removed:", jr, repr(string))
+
+        # # take off the last name
+        # try:
+        #     string, last = string.rsplit(maxsplit=1)
+        # except ValueError:
+        #     string, last = "", string
+
+        # now look for the von:
+        #  which can be before a double last name -- arrgg!
+        if string:
+            print("splitting on the von")
+            parts = string.split()
+            print(parts)
+            # look for the von parts:
+            if len(parts) == 1:  # only one token, must be the last name
+                last = parts[0]
+            else:
+                von1, von2 = -1, 0
+                for i, part in enumerate(parts):
+                    if author.firstislower(part):  # It's a von
+                        print("found a von:", part, von1, von2)
+                        von2 = i + 1
+                        von1 = i if von1 == -1 else von1
+                        print(von1, von2)
+                print("von indexes:", von1, von2)
+                if von1 > -1:
+                    von = " ".join(parts[von1:von2])
+                    if not first:
+                        first = " ".join(parts[:von1])
+                    last = " ".join(parts[von2:])
+                else:
+                    if first:
+                        last = " ".join(parts)
+                    else:
+                        last = parts[-1]
+                        first = " ".join(parts[:-1])
+
+        print("last name:", last)
+        first, von, last, jr = [author.post_process_brackets(s) for s in (first, von, last, jr)]
+        author.__init__(first, von, last, jr)
+        return author
+
+    def pre_processs_brackets(self, in_str, replace_and=False):
+        """
+        Replace whitespace and commas that are in brackets
+
+        So that they won't be used for splitting, etc.
+
+        fixme: It would probably be cleaner to write custom tokenizing code that
+               respects brackets, rather than this kludge - but this was easy
+        """
+        # make sure any whitespace is a single regular space charactor:
+        in_str = " ".join(in_str.split())
+        out = []
+        brackets = 0
+        for c in in_str:
+            if c == "{":
+                brackets += 1
+            elif c == "}":
+                brackets -= 1
+            if brackets:
+                if c == " ":
+                    out.append(self.replace_space)
+                elif c == ",":
+                    out.append(self.replace_comma)
+                else:
+                    out.append(c)
+            else:
+                out.append(c)
+        return "".join(out)
+
+    def post_process_brackets(self, in_str):
+        """
+        return the spaces and commas inside the brackets
+        """
+        return in_str.replace(self.replace_space, " ").replace(self.replace_comma, ",")
+
+    def __eq__(self, other):
+        """
+        nice to have a way to check that Auther instances are the same
+
+        for tests, if nothing else
+        """
+        try:
+            if (self.first == other.first and
+                self.von == other.von and
+                self.last == other.last and
+                self.jr == other.jr
+                ):
+                return True
+            else:
+                return False
+        except AttributeError:  # other is not a duck-typed Author instance
+            return False
+
+
+if __name__ == "__main__":
+
+    main()

--- a/bibtexparser/author_parse.py
+++ b/bibtexparser/author_parse.py
@@ -1,20 +1,11 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 
 """
-This script merges a new bib file with an existing one.
+This module allows parsing of author string in BiBTeX files.
 
-It is not very smart -- mostly what it does is give a "Chris Style" key.
-
-Then , with the merge it will make sure you don't have duplicate keys --
-but it will allow duplicate entries!
-
-We can make that smarter, later, but duplicates can be hard to identify!
-
-
-The "hard" part of this script is parsing the author string -- that's tricky!
-
-Using info from:
+It does its best to follow the BiBTeX model for author names,
+using info from:
 
 http://nwalsh.com/tex/texhelp/bibtx-23.html
 
@@ -22,224 +13,201 @@ and
 
 "The LaTeX companion"
 
-To figure out bibTeX author parsing
-
 The tests include all the examples in The LaTeX Companion (1993)
 
 NOTE: This would probably be more robust if it were re-written to do the tokenizing
       directly in a TeX aware way i.e. handling {} and \commands{} exactly like TeX does.
-      But then it couldn't use python's nifty built-in string methods.
+      But then it couldn't use python's nifty built-in string methods for splitting, etc.
 """
 
-import bibtexparser
+# imports to make code as py2-py3 compatible as possible
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
-new_filename = "endnote_export.bib"
-main_filename = "gnome_references.bib"
+from collections import namedtuple
+
+# some global constants:
+
+# These are used to prevent str.split() from spilling on things inside brackets
+# The use Unicode "Private use areas", so they wo'nt confilict with real text
+REPLACE_SPACE = "\uE000"
+REPLACE_COMMA = "\uE001"
+
+# using a namedtuple for the author -- so yu can get the parts, or simple use as a tuple
+
+Author = namedtuple('Author', ['first', 'von', 'last', 'jr'])
 
 
-class Author():
+def split_authors(author_str):
     """
-    Holds a Author object -- really just a few fields
-
-    Also contains code for parsing BiBTeX author strings
+    parses a complete author string to break up into multiple authors
+    returns a list of authors: each author is a string
     """
-    # using Unicode "Private use areas"
-    # these are used to replace spaces and commas inside {}
-    # so everyting within a bracket will be treated as one token
-    replace_space = "\uE000"  # "_"
-    replace_comma = "\uE001"  # "`"
-    replace_and = "\uE001"
+    print(author_str)
 
-    def __init__(self, first='', von='', last='', jr=''):
-        self.first = first.strip()
-        self.von = von.strip()
-        self.last = last.strip()
-        self.jr = jr.strip()
+    # splitting on "and", but bracket aware:
+    brackets = 0
+    and_ind = []
+    for i, c in enumerate(author_str[:]):
+        if c == "{":
+            brackets += 1
+        elif c == "}":
+            brackets -= 1
+        elif not brackets:
+            if author_str[i:i + 3] == "and":
+                and_ind.append(i)
+    print("and indexes:", and_ind)
+    authors = []
+    for i in and_ind:
+        print (author_str)
+        authors.append(author_str[:i].strip())
+        author_str = author_str[i + 3:]
+        print(authors, author_str)
+    authors.append(author_str.strip())
+    print(authors)
 
-    def split_authors(self, author_str):
-        """
-        parses the complete author string to break up multiple authors
+    return authors
 
-        returns a list of authors: each author is a string
-        """
-        print(author_str)
 
-        # splitting on "and", but bracket aware:
-        brackets = 0
-        and_ind = []
-        for i, c in enumerate(author_str[:]):
-            if c == "{":
-                brackets += 1
-            elif c == "}":
-                brackets -= 1
-            elif not brackets:
-                if author_str[i:i + 3] == "and":
-                    and_ind.append(i)
-        print("and indexes:", and_ind)
-        authors = []
-        for i in and_ind:
-            print (author_str)
-            authors.append(author_str[:i].strip())
-            author_str = author_str[i + 3:]
-            print(authors, author_str)
-        authors.append(author_str.strip())
-        print(authors)
+def firstislower(s):
+    """
+    an islower() function that finds if th first letter is lower case,
+    ignoring TeX control sequences
 
-        return authors
+    used to find "von" parts of names
+    """
+    ind = 0
+    in_control = False
+    for c in s:
+        if c == "{":
+            ind += 1
+            in_control = False
+        elif c == "\\":
+            ind += 1
+            in_control = True
+        else:
+            if not in_control:
+                return c.islower()
+    return False
 
-    @staticmethod
-    def firstislower(s):
-        """
-        an islower() function that finds if th first letter is lower case,
-        ignoring TeX control sequences
 
-        used to find "von" parts of names
-        """
-        ind = 0
-        in_control = False
-        for c in s:
-            if c == "{":
-                ind += 1
-                in_control = False
-            elif c == "\\":
-                ind += 1
-                in_control = True
+def parse_author(string):
+
+    r"""
+    parse a BiBTeX author string
+
+    This function finds the First, Von, Last, and Jr. parts of the author string
+    as defnined by teh BiBTeX spec.
+
+    :param string: the full author string (only one author)
+
+    :returns: named tuple of author parts: (first, von, last, jr) with fields:
+              author.first
+              author.von
+              author.last
+              author.jr
+              any piece that doesn't exist is an empty string
+
+    at least a last name is required.
+
+    Example:
+
+    >>> parse_author("von der Schmidt, Jr., Alex")
+    Author(first='Alex', von='von der', last='Schmidt', jr='Jr.')
+    >>>
+
+    Many more examples are in the tests.
+    """
+
+    string = pre_process_brackets(string)
+
+    first, von, last, jr = ('',) * 4
+    string = string.strip()
+    # if there is a comma, the first name is after the comma
+    if "," in string:
+        parts = string.rsplit(",", 1)
+        first = parts[1].strip()
+        string = parts[0].strip()
+
+        # now if there is still a comma, it's a Jr
+        print("first name removed:", first, repr(string))
+        parts = string.partition(",")
+        jr = parts[2].strip()
+        string = parts[0]
+        print("Jr removed:", jr, repr(string))
+
+    # now look for the von:
+    #  which can be before a double last name -- arrgg!
+    if string:
+        print("splitting on the von")
+        parts = string.split()
+        print(parts)
+        # look for the von parts:
+        if len(parts) == 1:  # only one token, must be the last name
+            last = parts[0]
+        else:
+            von1, von2 = -1, 0
+            for i, part in enumerate(parts):
+                if firstislower(part):  # It's a von
+                    print("found a von:", part, von1, von2)
+                    von2 = i + 1
+                    von1 = i if von1 == -1 else von1
+                    print(von1, von2)
+            print("von indexes:", von1, von2)
+            if von1 > -1:
+                von = " ".join(parts[von1:von2])
+                if not first:
+                    first = " ".join(parts[:von1])
+                last = " ".join(parts[von2:])
             else:
-                if not in_control:
-                    return c.islower()
-        return False
-
-    @classmethod
-    def from_string(cls, string):
-        # raw string -- there is a \u in there!
-        r"""
-        create an author object from a BiBTex compatible string
-
-        Apparently there are three options for names:
-
-        "First von Last" "von Last, First" "von Last, Jr, First"
-
-        So I use the number of commas to figure out which this is
-
-        fixme: this doesn't handle {} correctly -- {} can be used
-               to group extra stuff an commas into one part of a name.
-
-               it also won't handle capitalization of von:
-               Maria {\uppercase{d}e La} Cruz
-               (the von should be "De La")
-
-        """
-        author = cls()  # so we can use instance methods
-        string = author.pre_processs_brackets(string)
-
-        first, von, last, jr = ('',) * 4
-        string = string.strip()
-        # if there is a comma, the first name is after the comma
-        if "," in string:
-            parts = string.rsplit(",", 1)
-            first = parts[1].strip()
-            string = parts[0].strip()
-
-            # now if there is still a comma, it's a Jr
-            print("first name removed:", first, repr(string))
-            parts = string.partition(",")
-            jr = parts[2]
-            string = parts[0]
-            print("Jr removed:", jr, repr(string))
-
-        # # take off the last name
-        # try:
-        #     string, last = string.rsplit(maxsplit=1)
-        # except ValueError:
-        #     string, last = "", string
-
-        # now look for the von:
-        #  which can be before a double last name -- arrgg!
-        if string:
-            print("splitting on the von")
-            parts = string.split()
-            print(parts)
-            # look for the von parts:
-            if len(parts) == 1:  # only one token, must be the last name
-                last = parts[0]
-            else:
-                von1, von2 = -1, 0
-                for i, part in enumerate(parts):
-                    if author.firstislower(part):  # It's a von
-                        print("found a von:", part, von1, von2)
-                        von2 = i + 1
-                        von1 = i if von1 == -1 else von1
-                        print(von1, von2)
-                print("von indexes:", von1, von2)
-                if von1 > -1:
-                    von = " ".join(parts[von1:von2])
-                    if not first:
-                        first = " ".join(parts[:von1])
-                    last = " ".join(parts[von2:])
+                if first:
+                    last = " ".join(parts)
                 else:
-                    if first:
-                        last = " ".join(parts)
-                    else:
-                        last = parts[-1]
-                        first = " ".join(parts[:-1])
+                    last = parts[-1]
+                    first = " ".join(parts[:-1])
 
-        print("last name:", last)
-        first, von, last, jr = [author.post_process_brackets(s) for s in (first, von, last, jr)]
-        author.__init__(first, von, last, jr)
-        return author
+    print("last name:", last)
 
-    def pre_processs_brackets(self, in_str, replace_and=False):
-        """
-        Replace whitespace and commas that are in brackets
+    return Author(*[post_process_brackets(s) for s in (first, von, last, jr)])
 
-        So that they won't be used for splitting, etc.
 
-        fixme: It would probably be cleaner to write custom tokenizing code that
-               respects brackets, rather than this kludge - but this was easy
-        """
-        # make sure any whitespace is a single regular space charactor:
-        in_str = " ".join(in_str.split())
-        out = []
-        brackets = 0
-        for c in in_str:
-            if c == "{":
-                brackets += 1
-            elif c == "}":
-                brackets -= 1
-            if brackets:
-                if c == " ":
-                    out.append(self.replace_space)
-                elif c == ",":
-                    out.append(self.replace_comma)
-                else:
-                    out.append(c)
+def pre_process_brackets(in_str, replace_and=False):
+    """
+    Replace whitespace and commas that are in brackets
+
+    So that they won't be used for splitting, etc.
+
+    fixme: It would probably be cleaner to write custom tokenizing code that
+           respects brackets, rather than this kludge - but this was easy
+    """
+    # make sure any whitespace is a single regular space charactor:
+    in_str = " ".join(in_str.split())
+    out = []
+    brackets = 0
+    for c in in_str:
+        if c == "{":
+            brackets += 1
+        elif c == "}":
+            brackets -= 1
+        if brackets:
+            if c == " ":
+                out.append(REPLACE_SPACE)
+            elif c == ",":
+                out.append(REPLACE_COMMA)
             else:
                 out.append(c)
-        return "".join(out)
+        else:
+            out.append(c)
+    return "".join(out)
 
-    def post_process_brackets(self, in_str):
-        """
-        return the spaces and commas inside the brackets
-        """
-        return in_str.replace(self.replace_space, " ").replace(self.replace_comma, ",")
 
-    def __eq__(self, other):
-        """
-        nice to have a way to check that Auther instances are the same
-
-        for tests, if nothing else
-        """
-        try:
-            if (self.first == other.first and
-                self.von == other.von and
-                self.last == other.last and
-                self.jr == other.jr
-                ):
-                return True
-            else:
-                return False
-        except AttributeError:  # other is not a duck-typed Author instance
-            return False
+def post_process_brackets(in_str):
+    """
+    return the spaces and commas inside the brackets
+    """
+    return in_str.replace(REPLACE_SPACE, " ").replace(REPLACE_COMMA, ",")
 
 
 if __name__ == "__main__":

--- a/bibtexparser/tests/test_author_parse.py
+++ b/bibtexparser/tests/test_author_parse.py
@@ -16,13 +16,22 @@ from __future__ import unicode_literals
 
 import pytest
 
-from bibtexparser.author_parse import Author
+from bibtexparser.author_parse import (Author,
+                                       parse_author,
+                                       split_authors,
+                                       firstislower,
+                                       pre_process_brackets,
+                                       post_process_brackets,
+                                       )
+
+
+# fixme: This could be made much cleaner with parameterized tests!
 
 class Test_parse_name():
 
     def test_simplest(self):
         name = "Christopher Barker"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Christopher"
         assert author.last == "Barker"
         assert author.von == ""
@@ -30,7 +39,7 @@ class Test_parse_name():
 
     def test_last_only(self):
         name = "Barker"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == ""
         assert author.last == "Barker"
         assert author.von == ""
@@ -39,7 +48,7 @@ class Test_parse_name():
     def test_simple(self):
         """the no comma version"""
         name = "Donald E. Knuth"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Donald E."
         assert author.last == "Knuth"
         assert author.von == ""
@@ -48,7 +57,7 @@ class Test_parse_name():
     def test_simple2(self):
         """other ways of handling first name"""
         name = "D. E. Knuth"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "D. E."
         assert author.last == "Knuth"
         assert author.von == ""
@@ -57,7 +66,7 @@ class Test_parse_name():
     def test_simple2(self):
         """other ways of handling first name"""
         name = "D[onald] E. Knuth"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "D[onald] E."
         assert author.last == "Knuth"
         assert author.von == ""
@@ -68,7 +77,7 @@ class Test_parse_name():
     def test_option1(self):
         """the no comma version"""
         name = "First von Last"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "First"
         assert author.last == "Last"
         assert author.von == "von"
@@ -77,7 +86,7 @@ class Test_parse_name():
     def test_option2(self):
         """the no comma version"""
         name = "von Last, First"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "First"
         assert author.last == "Last"
         assert author.von == "von"
@@ -86,16 +95,24 @@ class Test_parse_name():
     def test_option3(self):
         """the no comma version"""
         name = "von Last, Jr, First"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "First"
         assert author.last == "Last"
         assert author.von == "von"
         assert author.jr == "Jr"
 
+    def test_all_parts(self):
+        name = "von der Schmidt, Jr., Alex"
+        author = parse_author(name)
+        assert author.first == "Alex"
+        assert author.last == "Schmidt"
+        assert author.von == "von der"
+        assert author.jr == "Jr."
+
     def test_fancy_von(self):
         """the no comma version"""
         name = "de la Porte, Files, Emile"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Emile"
         assert author.last == "Porte"
         assert author.von == "de la"
@@ -103,7 +120,7 @@ class Test_parse_name():
 
     def test_double_last(self):
         name = "Lopez Fernandez, Miguel"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Miguel"
         assert author.last == "Lopez Fernandez"
         assert author.von == ""
@@ -112,7 +129,7 @@ class Test_parse_name():
     def test_long_complex(self):
         """ example from The LaTeX companion """
         name = "Johannes Martinus Albertus van de Groene Heide"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Johannes Martinus Albertus"
         assert author.last == "Groene Heide"
         assert author.von == "van de"
@@ -121,7 +138,7 @@ class Test_parse_name():
     def test_hyphenated(self):
         """ example from The LaTeX companion """
         name = "Maria-Victoria Delgrande"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Maria-Victoria"
         assert author.last == "Delgrande"
         assert author.von == ""
@@ -130,7 +147,7 @@ class Test_parse_name():
     def test_von_and_first_last(self):
         """ example from The LaTeX companion """
         name = "von der Schmidt, Alex"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Alex"
         assert author.last == "Schmidt"
         assert author.von == "von der"
@@ -139,7 +156,7 @@ class Test_parse_name():
     def test_comma_junior(self):
         """ example from The LaTeX companion """
         name = "Smith, Jr., Robert"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Robert"
         assert author.last == "Smith"
         assert author.von == ""
@@ -148,7 +165,7 @@ class Test_parse_name():
     def test_von_in_brackets(self):
         """ example from The LaTeX companion """
         name = "{von der Schmidt}, Alex"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Alex"
         assert author.last == "{von der Schmidt}"
         assert author.von == ""
@@ -157,7 +174,7 @@ class Test_parse_name():
     def test_jr_in_brackets(self):
         """ example from The LaTeX companion """
         name = "{Lincoln Jr.}, John P."
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "John P."
         assert author.last == "{Lincoln Jr.}"
         assert author.von == ""
@@ -166,7 +183,7 @@ class Test_parse_name():
     def test_jr_in_brackets_end(self):
         """ example from The LaTeX companion """
         name = "John P. {Lincoln Jr.}"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "John P."
         assert author.last == "{Lincoln Jr.}"
         assert author.von == ""
@@ -179,7 +196,7 @@ class Test_parse_name():
             This is how it is suggested to have an uppercase von
         """
         name = r"Maria {\uppercase{d}e La} Cruz"
-        author = Author.from_string(name)
+        author = parse_author(name)
         assert author.first == "Maria"
         assert author.last == "Cruz"
         assert author.von == r"{\uppercase{d}e La}"
@@ -190,66 +207,63 @@ class Test_brackets():
     """
     test the bracket handling
     """
-    author = Author()
-
-    # fixme: these are hard-coding the replacement strings.
+    # fixme: these are hard-coding the replacement strings -- they chould get the constants
+    #        from the module
 
     def test_replace_space(self):
         string = "{von der Schmidt}, Alex)"
-        result = self.author.pre_processs_brackets(string)
+        result = pre_process_brackets(string)
 
         assert result == "{von\uE000der\uE000Schmidt}, Alex)"
 
     def test_replace_comma(self):
         string = "{This,that}, Alex)"
-        result = self.author.pre_processs_brackets(string)
+        result = pre_process_brackets(string)
 
         assert result == "{This\uE001that}, Alex)"
 
     def test_replace_both(self):
         string = "{Boss and Friends, Inc.} and {Snoozy and Boys, Ltd.}"
-        result = self.author.pre_processs_brackets(string)
+        result = pre_process_brackets(string)
 
         assert result == "{Boss\uE000and\uE000Friends\uE001\uE000Inc.} and {Snoozy\uE000and\uE000Boys\uE001\uE000Ltd.}"
 
     def test_replace_nested(self):
         string = "{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}"
-        result = self.author.pre_processs_brackets(string)
+        result = pre_process_brackets(string)
 
         assert result == "{Boss\uE000and\uE000Friends\uE001\uE000Inc.} and {{Snoozy\uE001\uE000Jr}\uE000and\uE000Boys\uE001\uE000Ltd.}"
 
     def test_reverse_both(self):
         string = "{Boss\uE000and\uE000Friends\uE001\uE000Inc.} and {{Snoozy\uE001\uE000Jr}\uE000and\uE000Boys\uE001\uE000Ltd.}"
-        result = self.author.post_process_brackets(string)
+        result = post_process_brackets(string)
         assert result == "{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}"
 
     def test_round_trip_both(self):
         string = "{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}"
-        result = self.author.pre_processs_brackets(string)
-        result = self.author.post_process_brackets(result)
+        result = pre_process_brackets(string)
+        result = post_process_brackets(result)
         assert result == string
 
     def test_firstislower(self):
-        assert Author.firstislower(r"{\uppercase{d}e La}")
+        assert firstislower(r"{\uppercase{d}e La}")
 
 
 class Test_author_split():
 
-    author = Author()
-
     def test_one_author(self):
-        authors = self.author.split_authors("Johannes Martinus Albertus van de Groene Heide")
+        authors = split_authors("Johannes Martinus Albertus van de Groene Heide")
         assert authors == ["Johannes Martinus Albertus van de Groene Heide"]
 
     def test_simple(self):
-        authors = self.author.split_authors("Frank Mittlebach and Rowley, Chris")
+        authors = split_authors("Frank Mittlebach and Rowley, Chris")
         assert authors == ["Frank Mittlebach", "Rowley, Chris"]
 
     def test_and_in_brackets(self):
-        authors = self.author.split_authors("{Lion and Nobel, Ltd}")
+        authors = split_authors("{Lion and Nobel, Ltd}")
         print("in test:", authors)
         assert authors == ["{Lion and Nobel, Ltd}"]
 
     def test_and_in_and_out_brackets(self):
-        authors = self.author.split_authors("{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}")
+        authors = split_authors("{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}")
         assert authors == ["{Boss and Friends, Inc.}", "{{Snoozy, Jr} and Boys, Ltd.}"]

--- a/bibtexparser/tests/test_author_parse.py
+++ b/bibtexparser/tests/test_author_parse.py
@@ -24,6 +24,17 @@ from bibtexparser.author_parse import (Author,
                                        post_process_brackets,
                                        )
 
+from bibtexparser.customization import splitname
+
+## little wrapper so I can test the splitname() function with the same tests.
+
+def parse_author(name_string):
+    result = splitname(name_string)
+
+    result = {key: " ".join(part) for key, part in result.items()}
+
+    return Author(result['first'], result['von'], result['last'], result['jr'])
+
 
 # fixme: This could be made much cleaner with parameterized tests!
 
@@ -197,6 +208,7 @@ class Test_parse_name():
         """
         name = r"Maria {\uppercase{d}e La} Cruz"
         author = parse_author(name)
+        print(author)
         assert author.first == "Maria"
         assert author.last == "Cruz"
         assert author.von == r"{\uppercase{d}e La}"

--- a/bibtexparser/tests/test_author_parse.py
+++ b/bibtexparser/tests/test_author_parse.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+
+"""
+test for author list parsing code -- really complex!
+
+These tests have every example that is in The LaTeX companion, so it's at least close!
+"""
+
+# imports to make code as py2-py3 compatible as possible
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# I really like pytest -- unittest is painful!
+
+import pytest
+
+from bibtexparser.author_parse import Author
+
+class Test_parse_name():
+
+    def test_simplest(self):
+        name = "Christopher Barker"
+        author = Author.from_string(name)
+        assert author.first == "Christopher"
+        assert author.last == "Barker"
+        assert author.von == ""
+        assert author.jr == ""
+
+    def test_last_only(self):
+        name = "Barker"
+        author = Author.from_string(name)
+        assert author.first == ""
+        assert author.last == "Barker"
+        assert author.von == ""
+        assert author.jr == ""
+
+    def test_simple(self):
+        """the no comma version"""
+        name = "Donald E. Knuth"
+        author = Author.from_string(name)
+        assert author.first == "Donald E."
+        assert author.last == "Knuth"
+        assert author.von == ""
+        assert author.jr == ""
+
+    def test_simple2(self):
+        """other ways of handling first name"""
+        name = "D. E. Knuth"
+        author = Author.from_string(name)
+        assert author.first == "D. E."
+        assert author.last == "Knuth"
+        assert author.von == ""
+        assert author.jr == ""
+
+    def test_simple2(self):
+        """other ways of handling first name"""
+        name = "D[onald] E. Knuth"
+        author = Author.from_string(name)
+        assert author.first == "D[onald] E."
+        assert author.last == "Knuth"
+        assert author.von == ""
+        assert author.jr == ""
+
+    # Apparently, there are three possible forms:
+    #  "First von Last" "von Last, First" "von Last, Jr, First"
+    def test_option1(self):
+        """the no comma version"""
+        name = "First von Last"
+        author = Author.from_string(name)
+        assert author.first == "First"
+        assert author.last == "Last"
+        assert author.von == "von"
+        assert author.jr == ""
+
+    def test_option2(self):
+        """the no comma version"""
+        name = "von Last, First"
+        author = Author.from_string(name)
+        assert author.first == "First"
+        assert author.last == "Last"
+        assert author.von == "von"
+        assert author.jr == ""
+
+    def test_option3(self):
+        """the no comma version"""
+        name = "von Last, Jr, First"
+        author = Author.from_string(name)
+        assert author.first == "First"
+        assert author.last == "Last"
+        assert author.von == "von"
+        assert author.jr == "Jr"
+
+    def test_fancy_von(self):
+        """the no comma version"""
+        name = "de la Porte, Files, Emile"
+        author = Author.from_string(name)
+        assert author.first == "Emile"
+        assert author.last == "Porte"
+        assert author.von == "de la"
+        assert author.jr == "Files"
+
+    def test_double_last(self):
+        name = "Lopez Fernandez, Miguel"
+        author = Author.from_string(name)
+        assert author.first == "Miguel"
+        assert author.last == "Lopez Fernandez"
+        assert author.von == ""
+        assert author.jr == ""
+
+    def test_long_complex(self):
+        """ example from The LaTeX companion """
+        name = "Johannes Martinus Albertus van de Groene Heide"
+        author = Author.from_string(name)
+        assert author.first == "Johannes Martinus Albertus"
+        assert author.last == "Groene Heide"
+        assert author.von == "van de"
+        assert author.jr == ""
+
+    def test_hyphenated(self):
+        """ example from The LaTeX companion """
+        name = "Maria-Victoria Delgrande"
+        author = Author.from_string(name)
+        assert author.first == "Maria-Victoria"
+        assert author.last == "Delgrande"
+        assert author.von == ""
+        assert author.jr == ""
+
+    def test_von_and_first_last(self):
+        """ example from The LaTeX companion """
+        name = "von der Schmidt, Alex"
+        author = Author.from_string(name)
+        assert author.first == "Alex"
+        assert author.last == "Schmidt"
+        assert author.von == "von der"
+        assert author.jr == ""
+
+    def test_comma_junior(self):
+        """ example from The LaTeX companion """
+        name = "Smith, Jr., Robert"
+        author = Author.from_string(name)
+        assert author.first == "Robert"
+        assert author.last == "Smith"
+        assert author.von == ""
+        assert author.jr == "Jr."
+
+    def test_von_in_brackets(self):
+        """ example from The LaTeX companion """
+        name = "{von der Schmidt}, Alex"
+        author = Author.from_string(name)
+        assert author.first == "Alex"
+        assert author.last == "{von der Schmidt}"
+        assert author.von == ""
+        assert author.jr == ""
+
+    def test_jr_in_brackets(self):
+        """ example from The LaTeX companion """
+        name = "{Lincoln Jr.}, John P."
+        author = Author.from_string(name)
+        assert author.first == "John P."
+        assert author.last == "{Lincoln Jr.}"
+        assert author.von == ""
+        assert author.jr == ""
+
+    def test_jr_in_brackets_end(self):
+        """ example from The LaTeX companion """
+        name = "John P. {Lincoln Jr.}"
+        author = Author.from_string(name)
+        assert author.first == "John P."
+        assert author.last == "{Lincoln Jr.}"
+        assert author.von == ""
+        assert author.jr == ""
+
+
+#    @pytest.mark.xfail
+    def test_uppercase_von(self):
+        """ example from The LaTeX companion
+            This is how it is suggested to have an uppercase von
+        """
+        name = r"Maria {\uppercase{d}e La} Cruz"
+        author = Author.from_string(name)
+        assert author.first == "Maria"
+        assert author.last == "Cruz"
+        assert author.von == r"{\uppercase{d}e La}"
+        assert author.jr == ""
+
+
+class Test_brackets():
+    """
+    test the bracket handling
+    """
+    author = Author()
+
+    # fixme: these are hard-coding the replacement strings.
+
+    def test_replace_space(self):
+        string = "{von der Schmidt}, Alex)"
+        result = self.author.pre_processs_brackets(string)
+
+        assert result == "{von\uE000der\uE000Schmidt}, Alex)"
+
+    def test_replace_comma(self):
+        string = "{This,that}, Alex)"
+        result = self.author.pre_processs_brackets(string)
+
+        assert result == "{This\uE001that}, Alex)"
+
+    def test_replace_both(self):
+        string = "{Boss and Friends, Inc.} and {Snoozy and Boys, Ltd.}"
+        result = self.author.pre_processs_brackets(string)
+
+        assert result == "{Boss\uE000and\uE000Friends\uE001\uE000Inc.} and {Snoozy\uE000and\uE000Boys\uE001\uE000Ltd.}"
+
+    def test_replace_nested(self):
+        string = "{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}"
+        result = self.author.pre_processs_brackets(string)
+
+        assert result == "{Boss\uE000and\uE000Friends\uE001\uE000Inc.} and {{Snoozy\uE001\uE000Jr}\uE000and\uE000Boys\uE001\uE000Ltd.}"
+
+    def test_reverse_both(self):
+        string = "{Boss\uE000and\uE000Friends\uE001\uE000Inc.} and {{Snoozy\uE001\uE000Jr}\uE000and\uE000Boys\uE001\uE000Ltd.}"
+        result = self.author.post_process_brackets(string)
+        assert result == "{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}"
+
+    def test_round_trip_both(self):
+        string = "{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}"
+        result = self.author.pre_processs_brackets(string)
+        result = self.author.post_process_brackets(result)
+        assert result == string
+
+    def test_firstislower(self):
+        assert Author.firstislower(r"{\uppercase{d}e La}")
+
+
+class Test_author_split():
+
+    author = Author()
+
+    def test_one_author(self):
+        authors = self.author.split_authors("Johannes Martinus Albertus van de Groene Heide")
+        assert authors == ["Johannes Martinus Albertus van de Groene Heide"]
+
+    def test_simple(self):
+        authors = self.author.split_authors("Frank Mittlebach and Rowley, Chris")
+        assert authors == ["Frank Mittlebach", "Rowley, Chris"]
+
+    def test_and_in_brackets(self):
+        authors = self.author.split_authors("{Lion and Nobel, Ltd}")
+        print("in test:", authors)
+        assert authors == ["{Lion and Nobel, Ltd}"]
+
+    def test_and_in_and_out_brackets(self):
+        authors = self.author.split_authors("{Boss and Friends, Inc.} and {{Snoozy, Jr} and Boys, Ltd.}")
+        assert authors == ["{Boss and Friends, Inc.}", "{{Snoozy, Jr} and Boys, Ltd.}"]


### PR DESCRIPTION
So I added a bunch of author parsing code, and only then discovered that 

customization.splitname() already existed.

And frankly, it's less kludgy than my code.

However, I ran all my tests against it, and there is a failure of an example from The LaTeX Companion.

I don't really think this code should be merged -- splitname() is a lot less kludgy -- but I thought I'd post it if folks are interested. 

I do think that we should fix splitname() to do the right thing with my tests -- and I also don't like the splitname API much

So I may submit a PR for that at some point.

