### PR TITLE
Fix `convert_to_unicode` for unbraced sequences

### DIFF
--- a/bibtexparser/customization.py
+++ b/bibtexparser/customization.py
@@ -7,11 +7,10 @@ You can find inspiration from these functions to design yours.
 Each of them takes a record and return the modified record.
 """
 
-import itertools
 import re
 import logging
 
-from bibtexparser.latexenc import unicode_to_latex, unicode_to_crappy_latex1, unicode_to_crappy_latex2, string_to_latex, protect_uppercase
+from bibtexparser.latexenc import latex_to_unicode, string_to_latex, protect_uppercase
 
 logger = logging.getLogger(__name__)
 
@@ -495,22 +494,7 @@ def convert_to_unicode(record):
     :returns: dict -- the modified record.
     """
     for val in record:
-        if '\\' in record[val] or '{' in record[val]:
-            for k, v in itertools.chain(unicode_to_crappy_latex1, unicode_to_latex):
-                if v in record[val]:
-                    record[val] = record[val].replace(v, k)
-
-        # If there is still very crappy items
-        if '\\' in record[val]:
-            for k, v in unicode_to_crappy_latex2:
-                if v in record[val]:
-                    parts = record[val].split(str(v))
-                    for key, record[val] in enumerate(parts):
-                        if key+1 < len(parts) and len(parts[key+1]) > 0:
-                            # Change order to display accents
-                            parts[key] = parts[key] + parts[key+1][0]
-                            parts[key+1] = parts[key+1][1:]
-                    record[val] = k.join(parts)
+        record[val] = latex_to_unicode(record[val])
     return record
 
 

--- a/bibtexparser/tests/test_customization.py
+++ b/bibtexparser/tests/test_customization.py
@@ -86,6 +86,11 @@ class TestBibtexParserMethod(unittest.TestCase):
         result = convert_to_unicode(record)
         expected = {'toto': 'ü ü'}
         self.assertEqual(result, expected)
+        # From issue 121
+        record = {'title': '{Two Gedenk\\"uberlieferung der Angelsachsen}'}
+        result = convert_to_unicode(record)
+        expected = {'title': '{Two Gedenküberlieferung der Angelsachsen}'}
+        self.assertEqual(result, expected)
 
     ###########
     # homogenize


### PR DESCRIPTION
`convert_to_unicode` customization was converting `\"u` (without braces)
to `\u0308u` which was supposed to be an `u` letter with an umlaut.
However, the `\u0308` unicode character is supposed to be *after* the
letter, contrary to the LaTeX encoding of the accent.

This commit fixes it and additionally wrap the `convert_to_unicode`
customization in a dedicated function that could be reused.

Closes #121.