### PR TITLE
Customization to strip fields of `{`, `}` etc

### DIFF
--- a/bibtexparser/tests/test_customization.py
+++ b/bibtexparser/tests/test_customization.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import unittest
 
-from bibtexparser.customization import getnames, convert_to_unicode, homogenize_latex_encoding, page_double_hyphen, keyword
+from bibtexparser.customization import getnames, convert_to_unicode, homogenize_latex_encoding, page_double_hyphen, keyword, add_plaintext_fields
 
 
 class TestBibtexParserMethod(unittest.TestCase):
@@ -99,6 +99,26 @@ class TestBibtexParserMethod(unittest.TestCase):
         record = {'toto': 'à {\`a} \`{a}'}
         result = homogenize_latex_encoding(record)
         expected = {'toto': '{\`a} {\`a} {\`a}'}
+        self.assertEqual(result, expected)
+
+    ###########
+    # add_plaintext_fields
+    ###########
+    def test_add_plaintext_fields(self):
+        record = {
+            'title': 'On-line {Recognition} of {Handwritten} {Mathematical} {Symbols}',
+            'foobar': ['{FFT} {Foobar}', '{foobar}'],
+            'foobar2': {'item1': '{FFT} {Foobar}', 'item2': '{foobar}'}
+        }
+        result = add_plaintext_fields(record)
+        expected = {
+            'title': 'On-line {Recognition} of {Handwritten} {Mathematical} {Symbols}',
+            'plain_title': 'On-line Recognition of Handwritten Mathematical Symbols',
+            'foobar': ['{FFT} {Foobar}', '{foobar}'],
+            'plain_foobar': ['FFT Foobar', 'foobar'],
+            'foobar2': {'item1': '{FFT} {Foobar}', 'item2': '{foobar}'},
+            'plain_foobar2': {'item1': 'FFT Foobar', 'item2': 'foobar'}
+        }
         self.assertEqual(result, expected)
 
     ###########

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+future>=0.16.0
 pyparsing>=2.0.3


### PR DESCRIPTION
Add a `add_plaintext_fields` customization to strip fields of braces and
similar characters, getting only the plaintext. It processes every
available fields and for each field, it adds a `plain_*` field
containing the plaintext version.

Should close #116.