### PR TITLE
Strip braces from `convert_to_unicode` output

### DIFF
--- a/bibtexparser/latexenc.py
+++ b/bibtexparser/latexenc.py
@@ -85,6 +85,9 @@ def latex_to_unicode(string):
     # to normalize to the latter.
     cleaned_string = unicodedata.normalize("NFC", "".join(cleaned_string))
 
+    # Remove any left braces
+    cleaned_string = cleaned_string.replace("{", "").replace("}", "")
+
     return cleaned_string
 
 

--- a/bibtexparser/tests/test_customization.py
+++ b/bibtexparser/tests/test_customization.py
@@ -89,7 +89,16 @@ class TestBibtexParserMethod(unittest.TestCase):
         # From issue 121
         record = {'title': '{Two Gedenk\\"uberlieferung der Angelsachsen}'}
         result = convert_to_unicode(record)
-        expected = {'title': '{Two Gedenküberlieferung der Angelsachsen}'}
+        expected = {'title': 'Two Gedenküberlieferung der Angelsachsen'}
+        self.assertEqual(result, expected)
+        # From issue 161
+        record = {'title': r"p\^{a}t\'{e}"}
+        result = convert_to_unicode(record)
+        expected = {'title': "pâté"}
+        self.assertEqual(result, expected)
+        record = {'title': r"\^{i}le"}
+        result = convert_to_unicode(record)
+        expected = {'title': "île"}
         self.assertEqual(result, expected)
 
     ###########


### PR DESCRIPTION
When using the `convert_to_unicode` customization, braces should be
stripped from the output.

This closes #161.