### PR TITLE
Fix: url replaced to link on homogenize_fields (#171)

### DIFF
--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -105,9 +105,9 @@ class BibTexParser(object):
             'keywords': u'keyword',
             'authors': u'author',
             'editors': u'editor',
-            'url': u'link',
-            'urls': u'link',
-            'links': u'link',
+            'urls': u'url',
+            'link': u'url',
+            'links': u'url',
             'subjects': u'subject'
         }
 

--- a/bibtexparser/tests/data/article_homogenize.bib
+++ b/bibtexparser/tests/data/article_homogenize.bib
@@ -1,0 +1,16 @@
+@ARTICLE{Cesar2013,
+  authors = {Jean César},
+  title = {An amazing title},
+  year = {2013},
+  month = "jan",
+  volume = {12},
+  pages = {12-23},
+  journal = {Nice Journal},
+  abstract = {This is an abstract. This line should be long enough to test
+multilines... and with a french érudit word},
+  comments = {A comment},
+  editors = {Edith Or},
+  keywords = {keyword1, keyword2},
+  links = {http://my.link/to-content},
+  subjects = "Some topic of interest",
+}

--- a/bibtexparser/tests/data/website.bib
+++ b/bibtexparser/tests/data/website.bib
@@ -1,6 +1,6 @@
 @misc{feder2006,
  title = {BibTeX},
  author = {Alexander Feder},
- url = {http://bibtex.org},
+ link = {http://bibtex.org},
  year = {2006}
 }

--- a/bibtexparser/tests/test_homogenise_fields.py
+++ b/bibtexparser/tests/test_homogenise_fields.py
@@ -1,25 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+import io
 import unittest
 from bibtexparser.bparser import BibTexParser
 
 
 class TestHomogenizeFields(unittest.TestCase):
+
     def test_homogenize_default(self):
         with open('bibtexparser/tests/data/website.bib', 'r') as bibfile:
             bib = BibTexParser(bibfile.read())
             entries = bib.get_entry_list()
-            self.assertNotIn('link', entries[0])
-            self.assertIn('url', entries[0])
+            self.assertNotIn('url', entries[0])
+            self.assertIn('link', entries[0])
 
     def test_homogenize_on(self):
         with open('bibtexparser/tests/data/website.bib', 'r') as bibfile:
             bib = BibTexParser(bibfile.read(), homogenize_fields=True)
             entries = bib.get_entry_list()
-            self.assertIn('link', entries[0])
-            self.assertNotIn('url', entries[0])
+            self.assertIn('url', entries[0])
+            self.assertNotIn('link', entries[0])
 
     def test_homogenize_off(self):
         with open('bibtexparser/tests/data/website.bib', 'r') as bibfile:
             bib = BibTexParser(bibfile.read(), homogenize_fields=False)
             entries = bib.get_entry_list()
-            self.assertNotIn('link', entries[0])
-            self.assertIn('url', entries[0])
+            self.assertNotIn('url', entries[0])
+            self.assertIn('link', entries[0])
+
+    def test_homogenizes_fields(self):
+        self.maxDiff = None
+        with io.open('bibtexparser/tests/data/article_homogenize.bib',
+                     'r', encoding='utf-8') as bibfile:
+            bib = BibTexParser(bibfile.read(), homogenize_fields=True)
+            expected_dict = {
+                'Cesar2013': {
+                    'keyword': 'keyword1, keyword2',
+                    'ENTRYTYPE': 'article',
+                    'abstract': 'This is an abstract. This line should be '
+                                'long enough to test\nmultilines... and with '
+                                'a french érudit word',
+                    'year': '2013',
+                    'journal': 'Nice Journal',
+                    'ID': 'Cesar2013',
+                    'pages': '12-23',
+                    'title': 'An amazing title',
+                    'comments': 'A comment',
+                    'author': 'Jean César',
+                    'volume': '12',
+                    'month': 'jan',
+                    'url': "http://my.link/to-content",
+                    'subject': "Some topic of interest",
+                    'editor': "Edith Or",
+                }
+            }
+            self.assertEqual(bib.get_entry_dict(), expected_dict)


### PR DESCRIPTION
- `urls`, `link`, and `links` are now replaced by `url`,
- adds some test to homogenize_fields.