### PR TITLE
Minor fixes

### DIFF
--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -47,6 +47,18 @@ class BibTexParser(object):
         parser.common_strings = False
         bib_database = bibtexparser.loads(bibtex_str, parser)
 
+    :param customization: function or None (default)
+        Customization to apply to parsed entries.
+    :param ignore_nonstandard_types: bool (default True)
+        If True ignores non-standard bibtex entry types.
+    :param homogenize_fields: bool (default False)
+        Common field name replacements (as set in alt_dict attribute).
+    :param interpolate_strings: bool (default True)
+        If True, replace bibtex string by their value, else uses
+        BibDataString objects.
+    :param common_strings: book (default False)
+        Include common string definitions (e.g. month abbreviations) to
+        the bibtex file.
     """
 
     def __new__(cls, data=None, **args):

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -54,13 +54,6 @@ def customizations_latex(record):
 
 class TestBibtexParserList(unittest.TestCase):
 
-    def test_wrong(self):
-        """
-        Wrong entry type
-        """
-        with open('bibtexparser/tests/data/wrong.bib', 'r') as bibfile:
-            self.assetRaises(TypeError, BibTexParser, bibfile)
-
     ###########
     # ARTICLE
     ###########

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -387,9 +387,6 @@ class TestBibtexParserList(unittest.TestCase):
 
         self.assertEqual(res, expected)
 
-    ###########
-    # TRAPS
-    ###########
     def test_traps(self):
         with codecs.open('bibtexparser/tests/data/traps.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read())
@@ -409,9 +406,6 @@ class TestBibtexParserList(unittest.TestCase):
                          }]
         self.assertEqual(res, expected)
 
-    ###########
-    # FEATURES
-    ###########
     def test_features(self):
         with open('bibtexparser/tests/data/features.bib', 'r') as bibfile:
             bib = BibTexParser(bibfile.read())
@@ -440,10 +434,7 @@ class TestBibtexParserList(unittest.TestCase):
                          }]
         self.assertEqual(res, expected)
 
-    ###########
-    # WRONG
-    ###########
-    def test_wrong(self):
+    def test_nonstandard_ignored(self):
         with open('bibtexparser/tests/data/wrong.bib', 'r') as bibfile:
             bib = BibTexParser(bibfile.read())
             res = bib.get_entry_list()
@@ -452,9 +443,12 @@ class TestBibtexParserList(unittest.TestCase):
                          'ENTRYTYPE': 'article'}]
         self.assertEqual(res, expected)
 
-    ###########
-    # ENCODING
-    ###########
+    def test_nonstandard_not_ignored(self):
+        with open('bibtexparser/tests/data/wrong.bib', 'r') as bibfile:
+            bib = BibTexParser(bibfile.read(), ignore_nonstandard_types=False)
+            res = bib.get_entry_list()
+        self.assertEqual(len(res), 2)
+
     def test_encoding(self):
         with codecs.open('bibtexparser/tests/data/encoding.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read())


### PR DESCRIPTION
– better test coverage for the `ignore_nonstandard` parameter (see #143),
– more documentation on `BibtexParser` parameters,
– small cleanup in `test_bparser`.