### PR TITLE
Handles declarations on lines starting with spaces after comments.

### DIFF
--- a/bibtexparser/bibtexexpression.py
+++ b/bibtexparser/bibtexexpression.py
@@ -176,7 +176,7 @@ class BibtexExpression(object):
 
         # Explicit comments: @comment + everything up to next valid declaration
         # starting on new line.
-        not_an_implicit_comment = (pp.LineStart() + pp.Literal('@')
+        not_an_implicit_comment = (pp.LineEnd() + pp.Literal('@')
                                    ) | pp.stringEnd()
         self.explicit_comment = (
             pp.Suppress(comment_line_start) +

--- a/bibtexparser/tests/data/comments_spaces_and_declarations.bib
+++ b/bibtexparser/tests/data/comments_spaces_and_declarations.bib
@@ -1,0 +1,21 @@
+% a comment
+ @preamble{ "Blah blah" }
+
+Another comment
+ @string{title = {A great title} }
+
+ and one more comment
+
+   @ARTICLE{Cesar2013,
+  author = {Jean César},
+  title = title,
+  year = {2013},
+  month = "jan",
+  volume = {12},
+  pages = {12-23},
+  journal = {Nice Journal},
+  abstract = {This is an abstract. This line should be long enough to test
+multilines... and with a french érudit word},
+  comments = {A comment},
+  keyword = {keyword1, keyword2},
+}

--- a/bibtexparser/tests/test_bibtexexpression.py
+++ b/bibtexparser/tests/test_bibtexexpression.py
@@ -54,3 +54,30 @@ class TestBibtexExpression(unittest.TestCase):
         result = self.expr.entry.parseString(
             '@journal{key, name = "àbcđéf" }')
         self.assertEqual(result.get('Fields'), {'name': 'àbcđéf'})
+
+    def test_entry_declaration_after_space(self):
+        self.expr.entry.parseString('  @journal{key, name = {abcd}}')
+
+    def test_string_declaration_after_space(self):
+        self.expr.string_def.parseString('  @string{ name = {abcd}}')
+
+    def test_preamble_declaration_after_space(self):
+        self.expr.preamble_decl.parseString('  @preamble{ "blah blah " }')
+
+    def test_declaration_after_space(self):
+        keys = []
+        self.expr.entry.addParseAction(
+            lambda s, l, t: keys.append(t.get('Key'))
+        )
+        self.expr.main_expression.parseString(' @journal{key, name = {abcd}}')
+        self.assertEqual(keys, ['key'])
+
+    def test_declaration_after_space_and_comment(self):
+        keys = []
+        self.expr.entry.addParseAction(
+            lambda s, l, t: keys.append(t.get('Key'))
+        )
+        self.expr.main_expression.parseString(
+            '% Implicit comment\n @article{key, name={abcd}}'
+        )
+        self.assertEqual(keys, ['key'])

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -6,8 +6,7 @@ import unittest
 import codecs
 
 from bibtexparser.bparser import BibTexParser
-from bibtexparser.bibdatabase import (COMMON_STRINGS, BibDataStringExpression,
-                                      BibDataString)
+from bibtexparser.bibdatabase import (COMMON_STRINGS, BibDataStringExpression)
 from bibtexparser.customization import *
 from bibtexparser import customization
 
@@ -553,6 +552,29 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertIsInstance(res['journal'], BibDataStringExpression)
         self.assertEqual(len(res['journal'].expr), 1)
         self.assertEqual(res['journal'].get_value(), 'Nice Journal')
+
+    def test_comments_spaces_and_declarations(self):
+        with codecs.open(
+                'bibtexparser/tests/data/comments_spaces_and_declarations.bib',
+                'r', 'utf-8') as bibfile:
+            bib = BibTexParser(bibfile.read())
+        res_dict = bib.get_entry_dict()
+        expected_dict = {'Cesar2013': {
+            'keyword': 'keyword1, keyword2',
+            'ENTRYTYPE': 'article',
+            'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+            'year': '2013',
+            'journal': 'Nice Journal',
+            'ID': 'Cesar2013',
+            'pages': '12-23',
+            'title': 'A great title',
+            'comments': 'A comment',
+            'author': 'Jean César',
+            'volume': '12',
+            'month': 'jan'
+        }}
+        self.assertEqual(res_dict, expected_dict)
+        self.assertEqual(bib.preambles, ["Blah blah"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
(See #198)

The parser currently skips declarations preceded by a space after a comment:
they are considered part of the implicit comment before. This behavior differs,
for example, from what biber would do on the same file. It is also not consistent
with the fact that a line started as " @string" is a valid string declaration.