### PR TITLE
Add support for BibLaTeX annotations

### DIFF
--- a/bibtexparser/bibtexexpression.py
+++ b/bibtexparser/bibtexexpression.py
@@ -154,7 +154,7 @@ class BibtexExpression(object):
         key.setParseAction(lambda s, l, t: first_token(s, l, t).strip())
 
         # Field name: word of letters, digits, dashes and underscores
-        field_name = pp.Word(pp.alphanums + '_-().')('FieldName')
+        field_name = pp.Word(pp.alphanums + '_-().+')('FieldName')
         field_name.setParseAction(first_token)
 
         # Field: field_name = value

--- a/bibtexparser/tests/data/article_with_annotation.bib
+++ b/bibtexparser/tests/data/article_with_annotation.bib
@@ -1,0 +1,14 @@
+@ARTICLE{Cesar2013,
+  author = {Jean César},
+  author+an = {1=highlight},
+  title = {An amazing title},
+  year = {2013},
+  month = "jan",
+  volume = {12},
+  pages = {12-23},
+  journal = {Nice Journal},
+  abstract = {This is an abstract. This line should be long enough to test
+multilines... and with a french érudit word},
+  comments = {A comment},
+  keyword = {keyword1, keyword2},
+}

--- a/bibtexparser/tests/data/article_with_annotation_output.bib
+++ b/bibtexparser/tests/data/article_with_annotation_output.bib
@@ -1,0 +1,15 @@
+@article{Cesar2013,
+ abstract = {This is an abstract. This line should be long enough to test
+multilines... and with a french érudit word},
+ author = {Jean César},
+ author+an = {1=highlight},
+ comments = {A comment},
+ journal = {Nice Journal},
+ keyword = {keyword1, keyword2},
+ month = {jan},
+ pages = {12-23},
+ title = {An amazing title},
+ volume = {12},
+ year = {2013}
+}
+

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -91,6 +91,42 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res_list, expected_list)
         self.assertEqual(res_dict, expected_dict)
 
+    def test_article_annotation(self):
+        with codecs.open('bibtexparser/tests/data/article_with_annotation.bib', 'r', 'utf-8') as bibfile:
+            bib = BibTexParser(bibfile.read())
+            res_list = bib.get_entry_list()
+            res_dict = bib.get_entry_dict()
+            expected_list = [{'keyword': 'keyword1, keyword2',
+                              'ENTRYTYPE': 'article',
+                              'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+                              'year': '2013',
+                              'journal': 'Nice Journal',
+                              'ID': 'Cesar2013',
+                              'pages': '12-23',
+                              'title': 'An amazing title',
+                              'comments': 'A comment',
+                              'author': 'Jean César',
+                              'author+an': '1=highlight',
+                              'volume': '12',
+                              'month': 'jan'
+                              }]
+            expected_dict = {'Cesar2013': {'keyword': 'keyword1, keyword2',
+                              'ENTRYTYPE': 'article',
+                              'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+                              'year': '2013',
+                              'journal': 'Nice Journal',
+                              'ID': 'Cesar2013',
+                              'pages': '12-23',
+                              'title': 'An amazing title',
+                              'comments': 'A comment',
+                              'author': 'Jean César',
+                              'author+an': '1=highlight',
+                              'volume': '12',
+                              'month': 'jan'
+                              }}
+        self.assertEqual(res_list, expected_list)
+        self.assertEqual(res_dict, expected_dict)
+
     def test_article_start_bom(self):
         with codecs.open('bibtexparser/tests/data/article_start_with_bom.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read())

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -111,19 +111,19 @@ class TestBibtexParserList(unittest.TestCase):
                               'month': 'jan'
                               }]
             expected_dict = {'Cesar2013': {'keyword': 'keyword1, keyword2',
-                              'ENTRYTYPE': 'article',
-                              'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
-                              'year': '2013',
-                              'journal': 'Nice Journal',
-                              'ID': 'Cesar2013',
-                              'pages': '12-23',
-                              'title': 'An amazing title',
-                              'comments': 'A comment',
-                              'author': 'Jean César',
-                              'author+an': '1=highlight',
-                              'volume': '12',
-                              'month': 'jan'
-                              }}
+                                           'ENTRYTYPE': 'article',
+                                           'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+                                           'year': '2013',
+                                           'journal': 'Nice Journal',
+                                           'ID': 'Cesar2013',
+                                           'pages': '12-23',
+                                           'title': 'An amazing title',
+                                           'comments': 'A comment',
+                                           'author': 'Jean César',
+                                           'author+an': '1=highlight',
+                                           'volume': '12',
+                                           'month': 'jan'
+                                           }}
         self.assertEqual(res_list, expected_list)
         self.assertEqual(res_dict, expected_dict)
 

--- a/bibtexparser/tests/test_bwriter.py
+++ b/bibtexparser/tests/test_bwriter.py
@@ -31,6 +31,17 @@ class TestBibtexWriterList(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(expected, result)
 
+    def test_article_with_annotation(self):
+        with io.open(_data_path('article_with_annotation.bib'), 'r') as bibfile:
+            bib = BibTexParser(bibfile.read())
+
+        with io.open(_data_path('article_with_annotation_output.bib'), 'r') \
+                as bibfile:
+            expected = bibfile.read()
+        result = to_bibtex(bib)
+        self.maxDiff = None
+        self.assertEqual(expected, result)
+
     def test_book(self):
         with io.open(_data_path('book.bib'), 'r') as bibfile:
             bib = BibTexParser(bibfile.read())


### PR DESCRIPTION
# Issue
BibLaTeX-style annotations result in entries being incorrectly parsed as `ImplicitComment`. 

For example, the following article entry will not parse because it contains "author+an":
```
@ARTICLE{Cesar2013,
  author = {Jean César},
  author+an = {1=highlight},
  title = {An amazing title},
  year = {2013},
  month = "jan",
  volume = {12},
  pages = {12-23},
  journal = {Nice Journal},
  abstract = {This is an abstract. This line should be long enough to test
multilines... and with a french érudit word},
  comments = {A comment},
  keyword = {keyword1, keyword2},
}
```


# Pull Request 
Support BibLaTeX-style annotations in entries by allowing the plus sign (+) in a field names. No support to use the annotations in any way is added.

# References
* [BibLaTeX Documentation](http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf), Section 3.6 Data Annotations (page 75)