### PR TITLE
Fix typo in pp.StringEnd

### DIFF
--- a/bibtexparser/bibtexexpression.py
+++ b/bibtexparser/bibtexexpression.py
@@ -177,7 +177,7 @@ class BibtexExpression(object):
         # Explicit comments: @comment + everything up to next valid declaration
         # starting on new line.
         not_an_implicit_comment = (pp.LineEnd() + pp.Literal('@')
-                                   ) | pp.stringEnd()
+                                   ) | pp.StringEnd()
         self.explicit_comment = (
             pp.Suppress(comment_line_start) +
             pp.originalTextFor(pp.SkipTo(not_an_implicit_comment),


### PR DESCRIPTION
For me on Ubuntu 14.04 LTS, with `python-bibtexparser` installed through pip3 (`--user`), `loads(...)` fails at that expression with:

```
# ...
  File "$HOME/.local/lib/python3.4/site-packages/bibtexparser/bibtexexpression.py", line 180, in __init__
    ) | pp.stringEnd()
TypeError: __call__() missing 1 required positional argument: 'name'
```

After a quick search I found out, that pyparsing functions are usually upper-case. I then changed `stringEnd`  to `StringEnd`, which made it work. I don't know whether this is a API change in pyparsing or whatever, so please excuse me if this is intentinal. I just thought I leave it here for you to investigate.

```sh
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 14.04.5 LTS
Release:	14.04
Codename:	trusty
$ python3 --version
Python 3.4.3
$ pip3 --version
pip 1.5.4 from /usr/lib/python3/dist-packages (python 3.4)
```