### PR TITLE
Checks for empty citekeys and whitespaces.

### DIFF
--- a/bibtexparser/bibtexexpression.py
+++ b/bibtexparser/bibtexexpression.py
@@ -34,36 +34,35 @@ def add_logger_parse_action(expr, log_func):
 
 # Parse action helpers
 # Helpers for returning values from the parsed tokens. Shaped as pyparsing's
-# parse actions. In pyparsing wording:
-# s, l, t, stand for string, location, token
+# parse actions. See pyparsing documentation for the arguments.
 
-def first_token(s, l, t):
+def first_token(string_, location, token):
     # TODO Handle this case correctly!
-    assert(len(t) == 1)
-    return t[0]
+    assert(len(token) == 1)
+    return token[0]
 
 
-def remove_trailing_newlines(s, l, t):
-    if t[0]:
-        return t[0].rstrip('\n')
+def remove_trailing_newlines(string_, location, token):
+    if token[0]:
+        return token[0].rstrip('\n')
 
 
-def remove_braces(s, l, t):
-    if len(t[0]) < 1:
+def remove_braces(string_, location, token):
+    if len(token[0]) < 1:
         return ''
     else:
-        start = 1 if t[0][0] == '{' else 0
-        end = -1 if t[0][-1] == '}' else None
-        return t[0][start:end]
+        start = 1 if token[0][0] == '{' else 0
+        end = -1 if token[0][-1] == '}' else None
+        return token[0][start:end]
 
 
-def field_to_pair(s, l, t):
+def field_to_pair(string_, location, token):
     """
     Looks for parsed element named 'Field'.
 
     :returns: (name, value).
     """
-    f = t.get('Field')
+    f = token.get('Field')
     return (f.get('FieldName'),
             strip_after_new_lines(f.get('Value')))
 
@@ -150,17 +149,23 @@ class BibtexExpression(object):
 
         # Entry key: any character up to a ',' without leading and trailing
         # spaces. Also exclude spaces and prevent it from being empty.
-        key = pp.SkipTo(',')('Key')  # TODO Maybe alsi exclude @',\#}{~%
+        key = pp.SkipTo(',')('Key')  # TODO Maybe also exclude @',\#}{~%
 
-        def citekeyParseAction(s, l, t):
-            key = first_token(s, l, t).strip()
+        def citekeyParseAction(string_, location, token):
+            """Parse action for validating citekeys.
+
+            It ensures citekey is not empty and has no space.
+
+            :args: see pyparsing documentation.
+            """
+            key = first_token(string_, location, token).strip()
             if len(key) < 1:
                 raise self.ParseException(
-                    s, loc=l, msg="Empty citekeys are not allowed.")
+                    string_, loc=location, msg="Empty citekeys are not allowed.")
             for i, c in enumerate(key):
                 if c.isspace():
                     raise self.ParseException(
-                        s, loc=(l + i),
+                        string_, loc=(location + i),
                         msg="Whitespace not allowed in citekeys.")
             return key
 

--- a/bibtexparser/tests/test_bibtexexpression.py
+++ b/bibtexparser/tests/test_bibtexexpression.py
@@ -58,6 +58,26 @@ class TestBibtexExpression(unittest.TestCase):
     def test_entry_declaration_after_space(self):
         self.expr.entry.parseString('  @journal{key, name = {abcd}}')
 
+    def test_entry_declaration_no_key(self):
+        with self.assertRaises(self.expr.ParseException):
+            self.expr.entry.parseString('@misc{name = {abcd}}')
+
+    def test_entry_declaration_no_key_new_line(self):
+        with self.assertRaises(self.expr.ParseException):
+            self.expr.entry.parseString('@misc{\n name = {abcd}}')
+
+    def test_entry_declaration_no_key_comma(self):
+        with self.assertRaises(self.expr.ParseException):
+            self.expr.entry.parseString('@misc{, \nname = {abcd}}')
+
+    def test_entry_declaration_no_key_keyvalue_without_space(self):
+        with self.assertRaises(self.expr.ParseException):
+            self.expr.entry.parseString('@misc{\nname=aaa}')
+
+    def test_entry_declaration_key_with_whitespace(self):
+        with self.assertRaises(self.expr.ParseException):
+            self.expr.entry.parseString('@misc{ xx yy, \n name = aaa}')
+
     def test_string_declaration_after_space(self):
         self.expr.string_def.parseString('  @string{ name = {abcd}}')
 

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -612,6 +612,13 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res_dict, expected_dict)
         self.assertEqual(bib.preambles, ["Blah blah"])
 
+    def test_no_citekey_parsed_as_comment(self):
+        bib = BibTexParser('@BOOK{, title = "bla"}')
+        self.assertEqual(bib.entries, [])
+        self.assertEqual(bib.preambles, [])
+        self.assertEqual(bib.strings, {})
+        self.assertEqual(bib.comments, ['@BOOK{, title = "bla"}'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #163.

Prevents empty citekeys and whitespaces in citekeys at parse time.