### PR TITLE
Feature: crossref Support

### DIFF
--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -1,9 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from collections import OrderedDict
 import sys
-
 import logging
-logger = logging.getLogger(__name__)
 
+logger = logging.getLogger(__name__)
 
 if sys.version_info.major == 2:
     TEXT_TYPE = unicode

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -114,14 +114,14 @@ class BibDatabase(object):
     def _add_missing_field_from_crossref_entry(self, entry, dependance = []):
         if entry["ID"] in self._crossref_updated:
             return
-        if entry["crossref"] not in self._entries_dict:
-            logger.error("Crossref reference %s for %s is missing.", entry["crossref"], entry["ID"])
+        if entry["_crossref"] not in self._entries_dict:
+            logger.error("Crossref reference %s for %s is missing.", entry["_crossref"], entry["ID"])
             return
-        if entry["crossref"] in dependance:
+        if entry["_crossref"] in dependance:
             logger.error("Circular crossref dependance : %s.", "->".join())
             return
-        crossref_entry = self._entries_dict[entry["crossref"]]
-        if "crossref" in crossref_entry:
+        crossref_entry = self._entries_dict[entry["_crossref"]]
+        if "_crossref" in crossref_entry:
             # update cross-ref for the cross-referenced entry
             dependance.append(self.entry["ID"])
             self._add_missing_field_from_crossref_entry(crossref_entry, dependance)
@@ -132,12 +132,13 @@ class BibDatabase(object):
         for bibfield,bibvalue in missing_field:
             entry[bibfield] = bibvalue
         self._crossref_updated.append(entry["ID"])
+        del entry["_crossref"]
 
     def _add_missing_field_from_crossref(self):
         self._make_entries_dict()
         self._crossref_updated = []
         for entry in self.entries:
-            if "crossref" in entry:
+            if "_crossref" in entry:
                 self._add_missing_field_from_crossref_entry(entry)
 
 

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -1,6 +1,9 @@
 from collections import OrderedDict
 import sys
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 if sys.version_info.major == 2:
     TEXT_TYPE = unicode
@@ -84,14 +87,17 @@ class BibDatabase(object):
             result.append(TEXT_TYPE(entry.get(field, '')).lower())  # Sorting always as string
         return tuple(result)
 
+    def _make_entries_dict(self):
+        for entry in self.entries:
+            self._entries_dict[entry['ID']] = entry
+
     def get_entry_dict(self):
         """Return a dictionary of BibTeX entries.
         The dict key is the BibTeX entry key
         """
         # If the hash has never been made, make it
         if not self._entries_dict:
-            for entry in self.entries:
-                self._entries_dict[entry['ID']] = entry
+            self._make_entries_dict()
         return self._entries_dict
 
     entries_dict = property(get_entry_dict)
@@ -102,6 +108,37 @@ class BibDatabase(object):
                 self.strings[name])
         except KeyError:
             raise(UndefinedString(name))
+
+    # TODO: (?) crossref is a single string of *one* bibtex key? or could-it be a list of bibtex key?
+    # For now, *one* bibkey
+    def _add_missing_field_from_crossref_entry(self, entry, dependance = []):
+        if entry["ID"] in self._crossref_updated:
+            return
+        if entry["crossref"] not in self._entries_dict:
+            logger.error("Crossref reference %s for %s is missing.", entry["crossref"], entry["ID"])
+            return
+        if entry["crossref"] in dependance:
+            logger.error("Circular crossref dependance : %s.", "->".join())
+            return
+        crossref_entry = self._entries_dict[entry["crossref"]]
+        if "crossref" in crossref_entry:
+            # update cross-ref for the cross-referenced entry
+            dependance.append(self.entry["ID"])
+            self._add_missing_field_from_crossref_entry(crossref_entry, dependance)
+            # Not really needed by it's cleaner
+            dependance.pop()
+
+        missing_field = ((bibfield,bibvalue) for (bibfield,bibvalue) in crossref_entry.items() if bibfield not in entry.keys())
+        for bibfield,bibvalue in missing_field:
+            entry[bibfield] = bibvalue
+        self._crossref_updated.append(entry["ID"])
+
+    def _add_missing_field_from_crossref(self):
+        self._make_entries_dict()
+        self._crossref_updated = []
+        for entry in self.entries:
+            if "crossref" in entry:
+                self._add_missing_field_from_crossref_entry(entry)
 
 
 class BibDataString(object):

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -70,9 +70,8 @@ class BibDatabase(object):
         #: List of BibTeX preamble (`@preamble{...}`) blocks.
         self.preambles = []
 
-        self.not_update_by_crossref = [
-            '_FROM_CROSSREF'
-        ]
+        #: List of fields that should not be updated when resolving crossrefs
+        self._not_updated_by_crossref = ['_FROM_CROSSREF']
 
     def load_common_strings(self):
         self.strings.update(COMMON_STRINGS)
@@ -142,7 +141,7 @@ class BibDatabase(object):
         from_crossref = {bibfield: bibvalue
                          for (bibfield, bibvalue) in crossref_entry.items()
                          if bibfield not in entry.keys() and
-                            bibfield not in self.not_update_by_crossref}
+                            bibfield not in self._not_updated_by_crossref}
 
         entry.update(from_crossref)
 

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -151,7 +151,7 @@ class BibDatabase(object):
         entry['_FROM_CROSSREF'] = sorted(from_crossref.keys())
         del entry['_crossref']
 
-    def _add_missing_from_crossref(self):
+    def add_missing_from_crossref(self):
         self._make_entries_dict()
         self._crossref_updated = []
         for entry in self.entries:

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -144,8 +144,7 @@ class BibDatabase(object):
                          if bibfield not in entry.keys() and
                             bibfield not in self.not_update_by_crossref}
 
-        for bibfield, bibvalue in from_crossref.items():
-            entry[bibfield] = bibvalue
+        entry.update(from_crossref)
 
         self._crossref_updated.append(entry['ID'])
         entry['_FROM_CROSSREF'] = sorted(from_crossref.keys())

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -128,10 +128,14 @@ class BibDatabase(object):
             # Not really needed by it's cleaner
             dependance.pop()
 
-        missing_field = ((bibfield,bibvalue) for (bibfield,bibvalue) in crossref_entry.items() if bibfield not in entry.keys())
-        for bibfield,bibvalue in missing_field:
+        missing_field = { bibfield:bibvalue for (bibfield,bibvalue) in crossref_entry.items() if bibfield not in entry.keys()}
+        for bibfield,bibvalue in missing_field.items():
             entry[bibfield] = bibvalue
+
         self._crossref_updated.append(entry["ID"])
+        # Add fields from crossref resolving ordered
+        entry["_FROM_CROSSREF"]=sorted(missing_field.keys())
+
         del entry["_crossref"]
 
     def _add_missing_field_from_crossref(self):

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -7,10 +7,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-if sys.version_info.major == 2:
-    TEXT_TYPE = unicode
+if sys.version_info >= (3, 0):
+    ustr = str
 else:
-    TEXT_TYPE = str
+    ustr = unicode
 
 
 STANDARD_TYPES = set([
@@ -90,7 +90,7 @@ class BibDatabase(object):
     def entry_sort_key(entry, fields):
         result = []
         for field in fields:
-            result.append(TEXT_TYPE(entry.get(field, '')).lower())  # Sorting always as string
+            result.append(ustr(entry.get(field, '')).lower())  # Sorting always as string
         return tuple(result)
 
     def _make_entries_dict(self):
@@ -279,4 +279,4 @@ def as_text(text_string_or_expression):
                   (BibDataString, BibDataStringExpression)):
         return text_string_or_expression.get_value()
     else:
-        return TEXT_TYPE(text_string_or_expression)
+        return ustr(text_string_or_expression)

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -67,6 +67,10 @@ class BibDatabase(object):
         #: List of BibTeX preamble (`@preamble{...}`) blocks.
         self.preambles = []
 
+        self.not_update_by_crossref = [
+            '_FROM_CROSSREF'
+            ]
+
     def load_common_strings(self):
         self.strings.update(COMMON_STRINGS)
 
@@ -109,32 +113,41 @@ class BibDatabase(object):
         except KeyError:
             raise(UndefinedString(name))
 
-    # TODO: (?) crossref is a single string of *one* bibtex key? or could-it be a list of bibtex key?
+    # TODO: (?) crossref is a single string of *one* bibtex key?
+    # or could-it be a list of bibtex key?
     # For now, *one* bibkey
-    def _add_missing_field_from_crossref_entry(self, entry, dependance = []):
+    def _add_missing_field_from_crossref_entry(self, entry, dependance=[]):
         if entry["ID"] in self._crossref_updated:
             return
         if entry["_crossref"] not in self._entries_dict:
-            logger.error("Crossref reference %s for %s is missing.", entry["_crossref"], entry["ID"])
+            logger.error("Crossref reference %s for %s is missing.",
+                         entry["_crossref"], entry["ID"])
             return
         if entry["_crossref"] in dependance:
-            logger.error("Circular crossref dependance : %s.", "->".join())
+            logger.error("Circular crossref dependance : %s->%s->%s.",
+                         "->".join(dependance),
+                         entry["ID"], entry["_crossref"])
             return
         crossref_entry = self._entries_dict[entry["_crossref"]]
         if "_crossref" in crossref_entry:
             # update cross-ref for the cross-referenced entry
-            dependance.append(self.entry["ID"])
-            self._add_missing_field_from_crossref_entry(crossref_entry, dependance)
+            dependance.append(entry["ID"])
+            self._add_missing_field_from_crossref_entry(crossref_entry,
+                                                        dependance)
             # Not really needed by it's cleaner
             dependance.pop()
 
-        missing_field = { bibfield:bibvalue for (bibfield,bibvalue) in crossref_entry.items() if bibfield not in entry.keys()}
-        for bibfield,bibvalue in missing_field.items():
+        missing_field = {bibfield: bibvalue
+                         for (bibfield, bibvalue) in crossref_entry.items()
+                         if bibfield not in entry.keys() and
+                         bibfield not in self.not_update_by_crossref}
+
+        for bibfield, bibvalue in missing_field.items():
             entry[bibfield] = bibvalue
 
         self._crossref_updated.append(entry["ID"])
         # Add fields from crossref resolving ordered
-        entry["_FROM_CROSSREF"]=sorted(missing_field.keys())
+        entry["_FROM_CROSSREF"] = sorted(missing_field.keys())
 
         del entry["_crossref"]
 

--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -120,7 +120,7 @@ class BibDatabase(object):
         if entry['ID'] in self._crossref_updated:
             return
 
-        if entry['_crossref'] not in self._entries_dict:
+        if entry['_crossref'] not in self.entries_dict:
             logger.error("Crossref reference %s for %s is missing.",
                          entry['_crossref'],
                          entry['ID'])
@@ -133,7 +133,7 @@ class BibDatabase(object):
                          entry['_crossref'])
             return
 
-        crossref_entry = self._entries_dict[entry['_crossref']]
+        crossref_entry = self.entries_dict[entry['_crossref']]
         if '_crossref' in crossref_entry:
             dependencies.add(entry['ID'])
             self._add_missing_from_crossref_entry(crossref_entry, dependencies)
@@ -152,7 +152,6 @@ class BibDatabase(object):
         del entry['_crossref']
 
     def add_missing_from_crossref(self):
-        self._make_entries_dict()
         self._crossref_updated = []
         for entry in self.entries:
             if "_crossref" in entry:

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -156,7 +156,7 @@ class BibTexParser(object):
                 raise exc
 
         if self.add_missing_from_crossref:
-            self.bib_database._add_missing_from_crossref()
+            self.bib_database.add_missing_from_crossref()
 
         return self.bib_database
 

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -130,6 +130,7 @@ class BibTexParser(object):
             'link': u'url',
             'links': u'url',
             'subjects': u'subject'
+            'xref': u'crossref'
         }
 
         # Setup the parser expression

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -80,7 +80,7 @@ class BibTexParser(object):
                  homogenize_fields=False,
                  interpolate_strings=True,
                  common_strings=False,
-                 add_missing_field_from_crossref=False):
+                 add_missing_from_crossref=False):
         """
         Creates a parser for rading BibTeX files
 
@@ -118,7 +118,7 @@ class BibTexParser(object):
         self.encoding = 'utf8'
 
         # Add missing field from cross-ref
-        self.add_missing_field_from_crossref = add_missing_field_from_crossref
+        self.add_missing_from_crossref = add_missing_from_crossref
 
         # pre-defined set of key changes
         self.alt_dict = {
@@ -129,7 +129,7 @@ class BibTexParser(object):
             'urls': u'url',
             'link': u'url',
             'links': u'url',
-            'subjects': u'subject'
+            'subjects': u'subject',
             'xref': u'crossref'
         }
 
@@ -154,8 +154,9 @@ class BibTexParser(object):
             logger.error("Could not parse properly, starting at %s", exc.line)
             if not partial:
                 raise exc
-        if self.add_missing_field_from_crossref:
-            self.bib_database._add_missing_field_from_crossref()
+
+        if self.add_missing_from_crossref:
+            self.bib_database._add_missing_from_crossref()
 
         return self.bib_database
 
@@ -285,15 +286,14 @@ class BibTexParser(object):
             d[self._clean_field_key(key)] = self._clean_val(fields[key])
         d['ENTRYTYPE'] = entry_type
         d['ID'] = entry_id
-        # Copy untouch cross-ref
+
         crossref = d.get('crossref', None)
+        if self.add_missing_from_crossref and crossref is not None:
+            d['_crossref'] = crossref
+
         if self.customization is not None:
-            # apply any customizations to the record object
-            # if we didn't use crossref then return it
             logger.debug('Apply customizations and return dict')
             d = self.customization(d)
-        if self.add_missing_field_from_crossref and crossref is not None:
-            d['_crossref'] = crossref
 
         self.bib_database.entries.append(d)
 

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -118,7 +118,7 @@ class BibTexParser(object):
         self.encoding = 'utf8'
 
         # Add missing field from cross-ref
-        self.add_missing_field_from_crossref=add_missing_field_from_crossref
+        self.add_missing_field_from_crossref = add_missing_field_from_crossref
 
         # pre-defined set of key changes
         self.alt_dict = {
@@ -294,7 +294,7 @@ class BibTexParser(object):
             d = self.customization(d)
         if self.add_missing_field_from_crossref and crossref is not None:
             d['_crossref'] = crossref
-    
+
         self.bib_database.entries.append(d)
 
     def _add_comment(self, comment):

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -79,7 +79,8 @@ class BibTexParser(object):
                  ignore_nonstandard_types=True,
                  homogenize_fields=False,
                  interpolate_strings=True,
-                 common_strings=False):
+                 common_strings=False,
+                 add_missing_field_from_crossref=False):
         """
         Creates a parser for rading BibTeX files
 
@@ -116,6 +117,9 @@ class BibTexParser(object):
         # hangs We are going to default to utf8, and mandate it.
         self.encoding = 'utf8'
 
+        # Add missing field from cross-ref
+        self.add_missing_field_from_crossref=add_missing_field_from_crossref
+
         # pre-defined set of key changes
         self.alt_dict = {
             'keyw': u'keyword',
@@ -149,6 +153,8 @@ class BibTexParser(object):
             logger.error("Could not parse properly, starting at %s", exc.line)
             if not partial:
                 raise exc
+        if self.add_missing_field_from_crossref:
+            self.bib_database._add_missing_field_from_crossref()
         return self.bib_database
 
     def parse_file(self, file, partial=False):

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -156,6 +156,7 @@ class BibTexParser(object):
                 raise exc
         if self.add_missing_field_from_crossref:
             self.bib_database._add_missing_field_from_crossref()
+
         return self.bib_database
 
     def parse_file(self, file, partial=False):
@@ -284,10 +285,16 @@ class BibTexParser(object):
             d[self._clean_field_key(key)] = self._clean_val(fields[key])
         d['ENTRYTYPE'] = entry_type
         d['ID'] = entry_id
+        # Copy untouch cross-ref
+        crossref = d.get('crossref', None)
         if self.customization is not None:
-            # apply any customizations to the record object then return it
+            # apply any customizations to the record object
+            # if we didn't use crossref then return it
             logger.debug('Apply customizations and return dict')
             d = self.customization(d)
+        if self.add_missing_field_from_crossref and crossref is not None:
+            d['_crossref'] = crossref
+    
         self.bib_database.entries.append(d)
 
     def _add_comment(self, comment):

--- a/bibtexparser/tests/data/biber-examples.bib
+++ b/bibtexparser/tests/data/biber-examples.bib
@@ -1,0 +1,1650 @@
+% From biber test data : t/tdata/examples.bib
+@STRING{anch-ie	  = {Angew.~Chem. Int.~Ed.} }
+@STRING{cup	  = {Cambridge University Press} }
+@STRING{dtv	  = {Deutscher Taschenbuch-Verlag} }
+@STRING{hup	  = {Harvard University Press} }
+@STRING{jams	  = {J.~Amer. Math. Soc.} }
+@STRING{jchph	  = {J.~Chem. Phys.} }
+@STRING{jomch	  = {J.~Organomet. Chem.} }
+@STRING{pup	  = {Princeton University Press} }
+
+@InCollection{westfahl:space,
+  crossref	  = {westfahl:frontier},
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Westfahl, Gary},
+  indextitle	  = {True Frontier, The},
+  title		  = {The True Frontier},
+  subtitle	  = {Confronting and Avoiding the Realities of Space in American Science Fiction
+		    Films},
+  pages		  = {55--65},
+  annotation	  = {A cross-referenced article from a \texttt{collection}. This is an
+		    \texttt{incollection} entry with a \texttt{crossref} field. Note the
+		    \texttt{subtitle} and \texttt{indextitle} fields}
+}
+
+@Set{set,
+  crossref	  = {set:herrmann},
+  entryset	  = {set:herrmann,set:aksin,set:yoon},
+  annotation	  = {A \texttt{set} entry with three members. Note the \texttt{entryset} and
+		    \texttt{crossref} fields. The cross-reference must point to the first member of
+		    the set}
+}
+
+@Set{stdmodel,
+  crossref	  = {stdmodel:glashow},
+  entryset	  = {stdmodel:glashow,stdmodel:weinberg,stdmodel:salam},
+  annotation	  = {A \texttt{set} entry with three members discussing the standard model of
+		    particle physics.}
+}
+
+@Set{stdmodel:ps_sc,
+  presort     = {zs},
+  crossref	  = {stdmodel:glashow},
+  entryset	  = {stdmodel:glashow,stdmodel:weinberg,stdmodel:salam},
+  annotation	  = {A \texttt{set} entry with three members discussing the standard model of
+		    particle physics. Note the \texttt{entryset} and \texttt{crossref} fields. The
+		    cross-reference must point to the first member of the set}
+}
+
+@Article{angenendt,
+  langid	  = {german},
+  author	  = {Angenendt, Arnold},
+  indextitle	  = {In Honore Salvatoris},
+  title		  = {In Honore Salvatoris~-- Vom Sinn und Unsinn der Patrozinienkunde},
+  shorttitle	  = {In Honore Salvatoris},
+  journaltitle	  = {Revue d'Histoire Eccl{\'e}siastique},
+  volume	  = {97},
+  year		  = {2002},
+  pages		  = {431--456, 791--823},
+  annotation	  = {A German article in a French journal. Apart from that, a typical
+		    \texttt{article} entry. Note the \texttt{indextitle} field}
+}
+
+@Article{angenendtsk,
+  sortkey      = {AATESTKEY},
+  langid	  = {german},
+  author	  = {Angenendt, Arnold},
+  indextitle	  = {In Honore Salvatoris},
+  title		  = {In Honore Salvatoris~-- Vom Sinn und Unsinn der Patrozinienkunde},
+  shorttitle	  = {In Honore Salvatoris},
+  journaltitle	  = {Revue d'Histoire Eccl{\'e}siastique},
+  volume	  = {97},
+  year		  = {2002},
+  pages		  = {431--456, 791--823},
+  annotation	  = {A German article in a French journal. Apart from that, a typical
+		    \texttt{article} entry. Note the \texttt{indextitle} field}
+}
+
+@Article{angenendtsa,
+  langid	  = {german},
+  shortauthor = {AA},
+  author	  = {Angenendt, Arnold},
+  indextitle	  = {In Honore Salvatoris},
+  title		  = {In Honore Salvatoris~-- Vom Sinn und Unsinn der Patrozinienkunde},
+  shorttitle	  = {In Honore Salvatoris},
+  journaltitle	  = {Revue d'Histoire Eccl{\'e}siastique},
+  volume	  = {97},
+  year		  = {2002},
+  pages		  = {431--456, 791--823},
+  annotation	  = {A German article in a French journal. Apart from that, a typical
+		    \texttt{article} entry. Note the \texttt{indextitle} field}
+}
+
+@Article{baez/article,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Baez, John C. and Lauda, Aaron D.},
+  title		  = {Higher-Dimensional Algebra V: 2-Groups},
+  journaltitle	  = {Theory and Applications of Categories},
+  volume	  = {12},
+  version	  = {3},
+  date		  = {2004},
+  pages		  = {423--491},
+  eprint	  = {math/0307200v3},
+  eprinttype	  = {arxiv},
+  annotation	  = {An \texttt{article} with \texttt{eprint} and \texttt{eprinttype} fields. Note
+		    that the arXiv reference is transformed into a clickable link if
+		    \texttt{hyperref} support has been enabled. Compare \texttt{baez\slash online}
+		    which is the same item given as an \texttt{online} entry}
+}
+
+@Article{bertram,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Bertram, Aaron and Wentworth, Richard},
+  title		  = {Gromov invariants for holomorphic maps on Riemann surfaces},
+  shorttitle	  = {Gromov invariants},
+  journaltitle	  = jams,
+  volume	  = {9},
+  number	  = {2},
+  year		  = {1996},
+  pages		  = {529--571},
+  annotation	  = {An \texttt{article} entry with a \texttt{volume} and a \texttt{number} field}
+}
+
+@Article{gillies,
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Gillies, Alexander},
+  title		  = {Herder and the Preparation of Goethe's Idea of World Literature},
+  journaltitle	  = {Publications of the English Goethe Society},
+  volume	  = {9},
+  series	  = {newseries},
+  year		  = {1933},
+  pages		  = {46--67},
+  annotation	  = {An \texttt{article} entry with a \texttt{series} and a \texttt{volume} field.
+		    Note that format of the \texttt{series} field in the database file}
+}
+
+@Article{kastenholz,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Kastenholz, M. A. and H{\"u}nenberger, Philippe H.},
+  indextitle	  = {Computation of ionic solvation free energies},
+  title		  = {Computation of methodology\hyphen independent ionic solvation free energies
+		    from molecular simulations},
+  subtitle	  = {I. The electrostatic potential in molecular liquids},
+  journaltitle	  = jchph,
+  volume	  = {124},
+  eid		  = {124106},
+  year		  = {2006},
+  doi		  = {10.1063/1.2172593},
+  annotation	  = {An \texttt{article} entry with an \texttt{eid} and a \texttt{doi} field. Note
+		    that the \textsc{doi} is transformed into a clickable link if \texttt{hyperref}
+		    support has been enabled},
+  abstract	  = {The computation of ionic solvation free energies from atomistic simulations is
+		    a surprisingly difficult problem that has found no satisfactory solution for
+		    more than 15 years. The reason is that the charging free energies evaluated from
+		    such simulations are affected by very large errors. One of these is related to
+		    the choice of a specific convention for summing up the contributions of solvent
+		    charges to the electrostatic potential in the ionic cavity, namely, on the basis
+		    of point charges within entire solvent molecules (M scheme) or on the basis of
+		    individual point charges (P scheme). The use of an inappropriate convention may
+		    lead to a charge-independent offset in the calculated potential, which depends
+		    on the details of the summation scheme, on the quadrupole-moment trace of the
+		    solvent molecule, and on the approximate form used to represent electrostatic
+		    interactions in the system. However, whether the M or P scheme (if any)
+		    represents the appropriate convention is still a matter of on-going debate. The
+		    goal of the present article is to settle this long-standing controversy by
+		    carefully analyzing (both analytically and numerically) the properties of the
+		    electrostatic potential in molecular liquids (and inside cavities within
+		    them).}
+}
+
+@Article{murray,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Hostetler, Michael J. and Wingate, Julia E. and Zhong, Chuan-Jian and Harris,
+		    Jay E. and Vachet, Richard W. and Clark, Michael R. and Londono, J. David and
+		    Green, Stephen J. and Stokes, Jennifer J. and Wignall, George D. and Glish, Gary
+		    L. and Porter, Marc D. and Evans, Neal D. and Murray, Royce W.},
+  indextitle	  = {Alkanethiolate gold cluster molecules},
+  title		  = {Alkanethiolate gold cluster molecules with core diameters from 1.5 to 5.2~nm},
+  subtitle	  = {Core and monolayer properties as a function of core size},
+  shorttitle	  = {Alkanethiolate gold cluster molecules},
+  journaltitle	  = {Langmuir},
+  volume	  = {14},
+  number	  = {1},
+  year		  = {1998},
+  pages		  = {17--30},
+  annotation	  = {An \texttt{article} entry with \arabic{author} authors. By default, long author
+		    and editor lists are automatically truncated. This is configurable}
+}
+
+@Article{reese,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Reese, Trevor R.},
+  title		  = {Georgia in Anglo-Spanish Diplomacy, 1736-1739},
+  journaltitle	  = {William and Mary Quarterly},
+  volume	  = {15},
+  series	  = {3},
+  year		  = {1958},
+  pages		  = {168--190},
+  annotation	  = {An \texttt{article} entry with a \texttt{series} and a \texttt{volume} field.
+		    Note the format of the series. If the value of the \texttt{series} field is an
+		    integer, this number is printed as an ordinal and the string \enquote*{series}
+		    is appended automatically}
+}
+
+@Article{set:aksin,
+  entryset	  = {set},
+  author	  = {Aks{\i}n, {\"O}zge and T{\"u}rkmen, Hayati and Artok, Levent and
+		    {\k{C}}etinkaya, Bekir and Ni, Chaoying and B{\"u}y{\"u}kg{\"u}ng{\"o}r, Orhan
+		    and {\"O}zkal, Erhan},
+  indextitle	  = {Effect of immobilization on catalytic characteristics},
+  title		  = {Effect of immobilization on catalytic characteristics of saturated
+		    Pd-N-heterocyclic carbenes in Mizoroki-Heck reactions},
+  journaltitle	  = jomch,
+  volume	  = {691},
+  number	  = {13},
+  year		  = {2006},
+  month           = {02},
+  pages		  = {3027--3036}
+}
+
+@Article{set:herrmann,
+  entryset	  = {set},
+  author	  = {Herrmann, Wolfgang A. and {\"O}fele, Karl and Schneider, Sabine K. and
+		    Herdtweck, Eberhardt and Hoffmann, Stephan D.},
+  indextitle	  = {Carbocyclic carbene as an efficient catalyst, A},
+  title		  = {A carbocyclic carbene as an efficient catalyst ligand for C--C coupling
+		    reactions},
+  journaltitle	  = anch-ie,
+  volume	  = {45},
+  number	  = {23},
+  year		  = {2006},
+  pages		  = {3859--3862}
+}
+
+@Article{set:yoon,
+  entryset	  = {set},
+  author	  = {Yoon, Myeong S. and Ryu, Dowook and Kim, Jeongryul and Ahn, Kyo Han},
+  indextitle	  = {Palladium pincer complexes},
+  title		  = {Palladium pincer complexes with reduced bond angle strain: efficient catalysts
+		    for the Heck reaction},
+  journaltitle	  = {Organometallics},
+  volume	  = {25},
+  number	  = {10},
+  year		  = {2006},
+  pages		  = {2409--2411}
+}
+
+@Article{shore,
+  author	  = {Shore, Bradd},
+  title		  = {Twice-Born, Once Conceived},
+  subtitle	  = {Meaning Construction and Cultural Cognition},
+  journaltitle	  = {American Anthropologist},
+  volume	  = {93},
+  series	  = {newseries},
+  number	  = {1},
+  month		  = mar,
+  year		  = {1991},
+  pages		  = {9--27},
+  annotation	  = {An \texttt{article} entry with \texttt{series}, \texttt{volume}, and
+		    \texttt{number} fields. Note the format of the \texttt{series} which is a
+		    localization key}
+}
+
+@Article{sigfridsson,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Sigfridsson, Emma and Ryde, Ulf},
+  indextitle	  = {Methods for deriving atomic charges},
+  title		  = {Comparison of methods for deriving atomic charges from the electrostatic
+		    potential and moments},
+  journaltitle	  = {Journal of Computational Chemistry},
+  volume	  = {19},
+  number	  = {4},
+  year		  = {1998},
+  doi		  = {10.1002/(SICI)1096-987X(199803)19:4<377::AID-JCC1>3.0.CO;2-P},
+  pages		  = {377--395},
+  annotation	  = {An \texttt{article} entry with \texttt{volume}, \texttt{number}, and
+		    \texttt{doi} fields. Note that the \textsc{doi} is transformed into a clickable
+		    link if \texttt{hyperref} support has been enabled},
+  abstract	  = { Four methods for deriving partial atomic charges from the quantum chemical
+		    electrostatic potential (CHELP, CHELPG, Merz-Kollman, and RESP) have been
+		    compared and critically evaluated. It is shown that charges strongly depend on
+		    how and where the potential points are selected. Two alternative methods are
+		    suggested to avoid the arbitrariness in the point-selection schemes and van der
+		    Waals exclusion radii: CHELP-BOW, which also estimates the charges from the
+		    electrostatic potential, but with potential points that are Boltzmann-weighted
+		    after their occurrence in actual simulations using the energy function of the
+		    program in which the charges will be used, and CHELMO, which estimates the
+		    charges directly from the electrostatic multipole moments. Different criteria
+		    for the quality of the charges are discussed.}
+}
+
+@Article{spiegelberg,
+  langid	  = {german},
+  sorttitle	  = {Intention und Intentionalitat in der Scholastik, bei Brentano und Husserl},
+  indexsorttitle  = {Intention und Intentionalitat in der Scholastik, bei Brentano und Husserl},
+  author	  = {Spiegelberg, Herbert},
+  title		  = {\mkbibquote{Intention} und \mkbibquote{Intentionalit{\"a}t} in der Scholastik, bei
+		    Brentano und Husserl},
+  shorttitle	  = {Intention und Intentionalit{\"a}t},
+  journaltitle	  = {Studia Philosophica},
+  volume	  = {29},
+  year		  = {1969},
+  pages		  = {189--216},
+  annotation	  = {An \texttt{article} entry. Note the \texttt{sorttitle} and
+		    \texttt{indexsorttitle} fields and the markup of the quotes in the database file}
+}
+
+@Article{springer,
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Springer, Otto},
+  title		  = {Mediaeval Pilgrim Routes from Scandinavia to Rome},
+  shorttitle	  = {Mediaeval Pilgrim Routes},
+  journaltitle	  = {Mediaeval Studies},
+  volume	  = {12},
+  year		  = {1950},
+  pages		  = {92--122},
+  annotation	  = {A plain \texttt{article} entry}
+}
+
+@Article{stdmodel:glashow,
+  entryset	  = {stdmodel},
+  author	  = {Glashow, Sheldon},
+  title		  = {Partial Symmetries of Weak Interactions},
+  journaltitle	  = {Nucl.~Phys.},
+  volume	  = {22},
+  year		  = {1961},
+  pages		  = {579\psqq}
+}
+
+@Article{stdmodel:weinberg,
+  entryset	  = {stdmodel},
+  author	  = {Weinberg, Steven},
+  title		  = {A Model of Leptons},
+  journaltitle	  = {Phys.~Rev.~Lett.},
+  volume	  = {19},
+  year		  = {1967},
+  pages		  = {1264\psqq}
+}
+
+@Book{aristotle:anima,
+  keywords	  = {primary},
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Aristotle},
+  editor	  = {Hicks, Robert Drew},
+  title		  = {De Anima},
+  publisher	  = cup,
+  location	  = {Cambridge},
+  year		  = {1907},
+  annotation	  = {A \texttt{book} entry with an \texttt{author} and an \texttt{editor}}
+}
+
+@Book{aristotle:physics,
+  keywords	  = {primary},
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Aristotle},
+  translator	  = {Wicksteed, P. H. and Cornford, F. M.},
+  title		  = {Physics},
+  shorttitle	  = {Physics},
+  publisher	  = {G. P. Putnam},
+  location	  = {New York},
+  year		  = {1929},
+  annotation	  = {A \texttt{book} entry with a \texttt{translator} field}
+}
+
+@Book{aristotle:poetics,
+  keywords	  = {primary},
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Aristotle},
+  editor	  = {Lucas, D. W.},
+  title		  = {Poetics},
+  shorttitle	  = {Poetics},
+  series	  = {Clarendon Aristotle},
+  publisher	  = {Clarendon Press},
+  location	  = {Oxford},
+  year		  = {1968},
+  annotation	  = {A \texttt{book} entry with an \texttt{author} and an \texttt{editor} as well as
+		    a \texttt{series} field}
+}
+
+@Book{aristotle:rhetoric,
+  keywords	  = {primary},
+  langid	  = {english},
+  langidopts = {variant=british},
+  sorttitle	  = {Rhetoric of Aristotle},
+  author	  = {Aristotle},
+  editor	  = {Cope, Edward Meredith},
+  commentator	  = {Cope, Edward Meredith},
+  indextitle	  = {Rhetoric of Aristotle, The},
+  title		  = {The Rhetoric of Aristotle with a commentary by the late Edward Meredith Cope},
+  shorttitle	  = {Rhetoric},
+  volumes	  = {3},
+  publisher	  = cup,
+  year		  = {1877},
+  annotation	  = {A commented edition. Note the concatenation of the \texttt{editor} and
+		    \texttt{commentator} fields as well as the \texttt{volumes}, \texttt{sorttitle},
+		    and \texttt{indextitle} fields}
+}
+
+@Book{augustine,
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Augustine, Robert L.},
+  title		  = {Heterogeneous catalysis for the synthetic chemist},
+  shorttitle	  = {Heterogeneous catalysis},
+  publisher	  = {Marcel Dekker},
+  location	  = {New York},
+  year		  = {1995},
+  annotation	  = {A plain \texttt{book} entry}
+}
+
+@Book{averroes/bland,
+  keywords	  = {primary},
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Averroes},
+  editor	  = {Bland, Kalman P.},
+  translator	  = {Bland, Kalman P.},
+  indextitle	  = {Epistle on the Possibility of Conjunction, The},
+  title		  = {The Epistle on the Possibility of Conjunction with the Active Intellect by Ibn
+		    Rushd with the Commentary of Moses Narboni},
+  shorttitle	  = {Possibility of Conjunction},
+  series	  = {Moreshet: Studies in Jewish History, Literature and Thought},
+  number	  = {7},
+  publisher	  = {Jewish Theological Seminary of America},
+  location	  = {New York},
+  year		  = {1982},
+  annotation	  = {A \texttt{book} entry with a \texttt{series} and a \texttt{number}. Note the
+		    concatenation of the \texttt{editor} and \texttt{translator} fields as well as
+		    the \texttt{indextitle} field}
+}
+
+@Book{averroes/hannes,
+  keywords	  = {primary},
+  langid	  = {german},
+  sorttitle	  = {Uber die Moglichkeit der Conjunktion},
+  indexsorttitle  = {Uber die Moglichkeit der Conjunktion},
+  author	  = {Averroes},
+  editor	  = {Hannes, Ludwig},
+  translator	  = {Hannes, Ludwig},
+  annotator	  = {Hannes, Ludwig},
+  indextitle	  = {{\"U}ber die M{\"o}glichkeit der Conjunktion},
+  title		  = {Des Averro{\"e}s Abhandlung: \mkbibquote{{\"U}ber die M{\"o}glichkeit der
+		    Conjunktion} oder \mkbibquote{{\"U}ber den materiellen Intellekt}},
+  shorttitle	  = {M{\"o}glichkeit der Conjunktion},
+  publisher	  = {C.~A. Kaemmerer},
+  location	  = {Halle an der Saale},
+  year		  = {1892},
+  annotation	  = {An annotated edition. Note the concatenation of the \texttt{editor},
+		    \texttt{translator}, and \texttt{annotator} fields. Also note the
+		    \texttt{shorttitle}, \texttt{indextitle}, \texttt{sorttitle}, and
+		    \texttt{indexsorttitle} fields}
+}
+
+@Book{averroes/hercz,
+  keywords	  = {primary},
+  langid	  = {german},
+  indexsorttitle  = {Drei Abhandlungen uber die Conjunction},
+  author	  = {Averroes},
+  editor	  = {Hercz, J.},
+  translator	  = {Hercz, J.},
+  indextitle	  = {Drei Abhandlungen {\"u}ber die Conjunction},
+  title		  = {Drei Abhandlungen {\"u}ber die Conjunction des separaten Intellects mit dem
+		    Menschen},
+  subtitle	  = {Von Averroes (Vater und Sohn), aus dem Arabischen {\"u}bersetzt von Samuel Ibn
+		    Tibbon},
+  shorttitle	  = {Drei Abhandlungen},
+  publisher	  = {S.~Hermann},
+  location	  = {Berlin},
+  year		  = {1869},
+  annotation	  = {A \texttt{book} entry. Note the concatenation of the \texttt{editor} and
+		    \texttt{translator} fields as well as the \texttt{indextitle} and
+		    \texttt{indexsorttitle} fields}
+}
+
+@Book{cicero,
+  langid	  = {german},
+  author	  = {Cicero, Marcus Tullius},
+  editor	  = {Blank-Sangmeister, Ursula},
+  translator	  = {Blank-Sangmeister, Ursula},
+  afterword	  = {Thraede, Klaus},
+  indextitle	  = {De natura deorum},
+  title		  = {De natura deorum. {\"U}ber das Wesen der G{\"o}tter},
+  shorttitle	  = {De natura deorum},
+  language	  = {langlatin and langgerman},
+  publisher	  = {Reclam},
+  location	  = {Stuttgart},
+  year		  = {1995},
+  annotation	  = {A bilingual edition of Cicero's \emph{De natura deorum}, with a German
+		    translation. Note the format of the \texttt{language} field in the database
+		    file, the concatenation of the \texttt{editor} and \texttt{translator} fields,
+		    and the \texttt{afterword} field}
+}
+
+@Book{coleridge,
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Coleridge, Samuel Taylor},
+  editor	  = {Coburn, Kathleen and Engell, James and Bate, W. Jackson},
+  indextitle	  = {Biographia literaria},
+  title		  = {Biographia literaria, or Biographical sketches of my literary life and
+		    opinions},
+  shorttitle	  = {Biographia literaria},
+  maintitle	  = {The collected works of Samuel Taylor Coleridge},
+  part		  = {2},
+  volume	  = {7},
+  series	  = {Bollingen Series},
+  number	  = {75},
+  publisher	  = {Routledge and Kegan Paul},
+  location	  = {London},
+  year		  = {1983},
+  annotation	  = {One (partial) volume of a multivolume book. This is a \texttt{book} entry with
+		    a \texttt{volume} and a \texttt{part} field which explicitly refers to the
+		    second (physical) part of the seventh (logical) volume. Also note the
+		    \texttt{series} and \texttt{number} fields}
+}
+
+@Book{companion,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {LaTeX Companion},
+  author	  = {Goossens, Michel and Mittelbach, Frank and Samarin, Alexander},
+  indextitle	  = {LaTeX Companion, The},
+  title		  = {The LaTeX Companion},
+  shorttitle	  = {LaTeX Companion},
+  edition	  = {1},
+  publisher	  = {Addison-Wesley},
+  location	  = {Reading, Mass.},
+  year		  = {1994},
+  annotation	  = {A book with three authors. Note the formatting of the author list. By default,
+		    only the first name is reversed in the bibliography}
+}
+
+@Book{cotton,
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Cotton, Frank Albert and Wilkinson, Geoffrey and Murillio, Carlos A. and
+		    Bochmann, Manfred},
+  title		  = {Advanced inorganic chemistry},
+  edition	  = {6},
+  publisher	  = {Wiley},
+  location	  = {Chichester},
+  year		  = {1999},
+  annotation	  = {A \texttt{book} entry with \arabic{author} authors and an \texttt{edition}
+		    field. By default, long \texttt{author} and \texttt{editor} lists are
+		    automatically truncated. This is configurable}
+}
+
+@Book{gerhardt,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {Federal Appointments Process},
+  author	  = {Gerhardt, Michael J.},
+  indextitle	  = {Federal Appointments Process, The},
+  title		  = {The Federal Appointments Process},
+  subtitle	  = {A Constitutional and Historical Analysis},
+  shorttitle	  = {Federal Appointments Process},
+  publisher	  = {Duke University Press},
+  location	  = {Durham and London},
+  year		  = {2000},
+  annotation	  = {This is a \texttt{book} entry. Note the format of the \texttt{location} field
+		    as well as the \texttt{sorttitle} and \texttt{indextitle} fields}
+}
+
+@Book{gonzalez,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {Ghost of John Wayne and Other Stories},
+  author	  = {Gonzalez, Ray},
+  indextitle	  = {Ghost of John Wayne and Other Stories, The},
+  title		  = {The Ghost of John Wayne and Other Stories},
+  shorttitle	  = {Ghost of John Wayne},
+  publisher	  = {The University of Arizona Press},
+  location	  = {Tucson},
+  year		  = {2001},
+  isbn		  = {0-816-52066-6},
+  annotation	  = {A collection of short stories. This is a \texttt{book} entry. Note the
+		    \texttt{sorttitle} and \texttt{indextitle} fields in the database file. There's
+		    also an \texttt{isbn} field}
+}
+
+@Book{hammond,
+  langid	  = {english},
+  langidopts = {variant=british},
+  sorttitle	  = {Basics of crystallography and diffraction},
+  author	  = {Hammond, Christopher},
+  indextitle	  = {Basics of crystallography and diffraction, The},
+  title		  = {The basics of crystallography and diffraction},
+  shorttitle	  = {Crystallography and diffraction},
+  publisher	  = {International Union of Crystallography and Oxford University Press},
+  location	  = {Oxford},
+  year		  = {1997},
+  annotation	  = {A \texttt{book} entry. Note the \texttt{sorttitle} and \texttt{indextitle}
+		    fields as well as the format of the \texttt{publisher} field}
+}
+
+@Book{iliad,
+  langid	  = {german},
+  sorttitle	  = {Ilias},
+  author	  = {Homer},
+  translator	  = {Schadewaldt, Wolfgang},
+  introduction	  = {Latacz, Joachim},
+  indextitle	  = {Ilias, Die},
+  title		  = {Die Ilias},
+  shorttitle	  = {Ilias},
+  edition	  = {3},
+  publisher	  = {Artemis \& Winkler},
+  location	  = {D{\"u}sseldorf and Z{\"u}rich},
+  year		  = {2004},
+  annotation	  = {A German translation of the \emph{Iliad}. Note the \texttt{translator} and
+		    \texttt{introduction} fields and the format of the \texttt{location} field in
+		    the database file. Also note the \texttt{sorttitle} and \texttt{indextitle} fields}
+}
+
+@Book{knuth:ct,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sortyear	  = {1984-0},
+  sorttitle	  = {Computers & Typesetting},
+  indexsorttitle  = {Computers & Typesetting},
+  author	  = {Knuth, Donald E.},
+  title		  = {Computers \& Typesetting},
+  volumes	  = {5},
+  publisher	  = {Addison-Wesley},
+  location	  = {Reading, Mass.},
+  date		  = {1984/1986},
+  annotation	  = {A five-volume book cited as a whole. This is a \texttt{book} entry, note the
+		    \texttt{volumes} field}
+}
+
+@Book{knuth:ct:a,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sortyear	  = {1984-1},
+  sorttitle	  = {Computers & Typesetting A},
+  indexsorttitle  = {The TeXbook},
+  author	  = {Knuth, Donald E.},
+  indextitle	  = {\TeX book, The},
+  title		  = {The \TeX book},
+  shorttitle	  = {\TeX book},
+  maintitle	  = {Computers \& Typesetting},
+  volume	  = {A},
+  publisher	  = {Addison-Wesley},
+  location	  = {Reading, Mass.},
+  year		  = {1984},
+  annotation	  = {The first volume of a five-volume book. Note the \texttt{sorttitle} and
+		    \texttt{sortyear} fields. We want this volume to be listed after the entry
+		    referring to the entire five-volume set. Also note the \texttt{indextitle} and
+		    \texttt{indexsorttitle} fields}
+}
+
+@Book{knuth:ct:b,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sortyear	  = {1984-2},
+  sorttitle	  = {Computers & Typesetting B},
+  indexsorttitle  = {TeX: The Program},
+  author	  = {Knuth, Donald E.},
+  title		  = {\TeX: The Program},
+  shorttitle	  = {\TeX},
+  maintitle	  = {Computers \& Typesetting},
+  volume	  = {B},
+  publisher	  = {Addison-Wesley},
+  location	  = {Reading, Mass.},
+  year		  = {1986},
+  annotation	  = {The second volume of a five-volume book. Note the \texttt{sorttitle} and
+		    \texttt{sortyear} fields. Also note the \texttt{indexsorttitle} field}
+}
+
+@Book{knuth:ct:c,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sortyear	  = {1984-3},
+  sorttitle	  = {Computers & Typesetting C},
+  author	  = {Knuth, Donald E.},
+  indextitle	  = {METAFONTbook, The},
+  title		  = {The METAFONTbook},
+  shorttitle	  = {METAFONTbook},
+  maintitle	  = {Computers \& Typesetting},
+  volume	  = {C},
+  publisher	  = {Addison-Wesley},
+  location	  = {Reading, Mass.},
+  year		  = {1986},
+  annotation	  = {The third volume of a five-volume book. Note the \texttt{sorttitle} and
+		    \texttt{sortyear} fields as well as the \texttt{indextitle} field}
+}
+
+@Book{knuth:ct:d,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sortyear	  = {1984-4},
+  sorttitle	  = {Computers & Typesetting D},
+  author	  = {Knuth, Donald E.},
+  title		  = {METAFONT: The Program},
+  shorttitle	  = {METAFONT},
+  maintitle	  = {Computers \& Typesetting},
+  volume	  = {D},
+  publisher	  = {Addison-Wesley},
+  location	  = {Reading, Mass.},
+  year		  = {1986},
+  annotation	  = {The fourth volume of a five-volume book. Note the \texttt{sorttitle} and
+		    \texttt{sortyear} fields}
+}
+
+@Book{knuth:ct:e,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sortyear	  = {1984-5},
+  sorttitle	  = {Computers & Typesetting E},
+  author	  = {Knuth, Donald E.},
+  title		  = {Computer Modern Typefaces},
+  maintitle	  = {Computers \& Typesetting},
+  volume	  = {E},
+  publisher	  = {Addison-Wesley},
+  location	  = {Reading, Mass.},
+  year		  = {1986},
+  annotation	  = {The fifth volume of a five-volume book. Note the \texttt{sorttitle} and
+		    \texttt{sortyear} fields}
+}
+
+@Book{malinowski,
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Malinowski, Bronis{\l}aw},
+  title		  = {Argonauts of the Western Pacific},
+  subtitle	  = {An account of native enterprise and adventure in the Archipelagoes of
+		    Melanesian New Guinea},
+  shorttitle	  = {Argonauts},
+  edition	  = {8},
+  publisher	  = {Routledge and Kegan Paul},
+  location	  = {London},
+  year		  = {1972},
+  annotation	  = {This is a \texttt{book} entry. Note the format of the \texttt{publisher} and
+		    \texttt{edition} fields as well as the \texttt{subtitle} field}
+}
+
+@Book{maron,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Maron, Monika},
+  translator	  = {Brigitte Goldstein},
+  title		  = {Animal Triste},
+  shorttitle	  = {Animal Triste},
+  publisher	  = {University of Nebraska Press},
+  location	  = {Lincoln},
+  year		  = {2000},
+  origlanguage	  = {german},
+  annotation	  = {An English translation of a German novel with a French title. In other words: a
+		    \texttt{book} entry with a \texttt{translator} field. Note the
+		    \texttt{origlanguage} field which is concatenated with the \texttt{translator}}
+}
+
+@Book{massa,
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {Werner Massa},
+  title		  = {Crystal structure determination},
+  edition	  = {2},
+  publisher	  = {Spinger},
+  location	  = {Berlin},
+  year		  = {2004},
+  annotation	  = {A \texttt{book} entry with an \texttt{edition} field}
+}
+
+@Book{nietzsche:ksa,
+  langid	  = {german},
+  sortyear	  = {1988-00-000},
+  sorttitle	  = {Werke-00-000},
+  indexsorttitle  = {Samtliche Werke},
+  author	  = {Nietzsche, Friedrich},
+  editor	  = {Colli, Giorgio and Montinari, Mazzino},
+  title		  = {S{\"a}mtliche Werke},
+  subtitle	  = {Kritische Studienausgabe},
+  volumes	  = {15},
+  edition	  = {2},
+  publisher	  = dtv # { and Walter de Gruyter},
+  location	  = {M{\"u}nchen and Berlin and New York},
+  year		  = {1988},
+  annotation	  = {The critical edition of Nietzsche's works. This is a \texttt{book} entry
+		    referring to a 15-volume work as a whole. Note the \texttt{volumes} field and
+		    the format of the \texttt{publisher} and \texttt{location} fields in the
+		    database file. Also note the \texttt{sorttitle} and \texttt{sortyear} fields
+		    which are used to fine-tune the sorting order of the bibliography. We want this
+		    item listed first in the bibliography}
+}
+
+@Book{nietzsche:ksa1,
+  langid	  = {german},
+  sortyear	  = {1988-01-000},
+  sorttitle	  = {Werke-01-000},
+  indexsorttitle  = {Samtliche Werke I},
+  author	  = {Nietzsche, Friedrich},
+  bookauthor	  = {Nietzsche, Friedrich},
+  editor	  = {Colli, Giorgio and Montinari, Mazzino},
+  indextitle	  = {S{\"a}mtliche Werke I},
+  title		  = {Die Geburt der Trag{\"o}die. Unzeitgem{\"a}{\ss}e Betrachtungen I--IV.
+		    Nachgelassene Schriften 1870--1973},
+  shorttitle	  = {S{\"a}mtliche Werke I},
+  maintitle	  = {S{\"a}mtliche Werke},
+  mainsubtitle	  = {Kritische Studienausgabe},
+  volume	  = {1},
+  edition	  = {2},
+  publisher	  = dtv # { and Walter de Gruyter},
+  location	  = {M{\"u}nchen and Berlin and New York},
+  year		  = {1988},
+  annotation	  = {A single volume from the critical edition of Nietzsche's works. This
+		    \texttt{book} entry explicitly refers to the first volume only. Note the
+		    \texttt{title} and \texttt{maintitle} fields. Also note the \texttt{sorttitle}
+		    and \texttt{sortyear} fields. We want this entry to be listed after the entry
+		    referring to the entire edition}
+}
+
+@Book{nussbaum,
+  keywords	  = {secondary},
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {Aristotle's De Motu Animalium},
+  indexsorttitle  = {Aristotle's De Motu Animalium},
+  author	  = {Nussbaum, Martha},
+  title		  = {Aristotle's \mkbibquote{De Motu Animalium}},
+  publisher	  = pup,
+  location	  = {Princeton},
+  year		  = {1978},
+  annotation	  = {A \texttt{book} entry. Note the \texttt{sorttitle} and \texttt{indexsorttitle}
+		    fields and the markup of the quotes in the database file}
+}
+
+@Book{piccato,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Piccato, Pablo},
+  title		  = {City of Suspects},
+  subtitle	  = {Crime in Mexico City, 1900--1931},
+  shorttitle	  = {City of Suspects},
+  publisher	  = {Duke University Press},
+  location	  = {Durham and London},
+  year		  = {2001},
+  annotation	  = {This is a \texttt{book} entry. Note the format of the \texttt{location} field
+		    in the database file}
+}
+
+@Book{vangennep,
+  options	  = {useprefix},
+  langid	  = {french},
+  sorttitle	  = {Rites de passage},
+  author	  = {van Gennep, Arnold},
+  indextitle	  = {Rites de passage, Les},
+  title		  = {Les rites de passage},
+  shorttitle	  = {Rites de passage},
+  publisher	  = {Nourry},
+  location	  = {Paris},
+  year		  = {1909},
+  annotation	  = {A \texttt{book} entry. Note the format of the printed name and compare the
+		    \texttt{useprefix} option in the \texttt{options} field as well as
+		    \texttt{brandt} and \texttt{geer}}
+}
+
+@Book{vangennepx,
+  langid	  = {french},
+  author	  = {van Gennep, Jean},
+  title		  = {Il a neigé à Port-au-Prince},
+  publisher	  = {Alhambra},
+  location	  = {Montréal},
+  year		  = {1999}
+}
+
+@Book{vazques-de-parga,
+  langid	  = {spanish},
+  sorttitle	  = {Peregrinaciones a Santiago de Compostela},
+  author	  = {V{\'a}zques{ de }Parga, Luis and Lacarra, Jos{\'e} Mar{\'i}a and Ur{\'i}a
+		    R{\'i}u, Juan},
+  indextitle	  = {Peregrinaciones a Santiago de Compostela, Las},
+  title		  = {Las Peregrinaciones a Santiago de Compostela},
+  shorttitle	  = {Peregrinaciones},
+  volumes	  = {3},
+  publisher	  = {Iberdrola},
+  location	  = {Pamplona},
+  year		  = {1993},
+  note		  = {Ed. facs. de la realizada en 1948--49},
+  annotation	  = {A multivolume book cited as a whole. This is a \texttt{book} entry with
+		    \texttt{volumes}, \texttt{note}, \texttt{sorttitle}, and \texttt{indextitle} fields}
+}
+
+@Book{worman,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {Cast of Character},
+  author	  = {Worman, Nancy},
+  indextitle	  = {Cast of Character, The},
+  title		  = {The Cast of Character},
+  subtitle	  = {Style in Greek Literature},
+  shorttitle	  = {Cast of Character},
+  publisher	  = {University of Texas Press},
+  location	  = {Austin},
+  year		  = {2002},
+  annotation	  = {A \texttt{book} entry. Note the \texttt{sorttitle} and \texttt{indextitle}
+		    fields}
+}
+
+@Book{wormanx,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {Someone did it again},
+  author	  = {Worman, Nana},
+  indextitle	  = {Someone did it again},
+  title		  = {Someone did it again},
+  publisher	  = {University of Nowhere Press},
+  location	  = {Somewhere},
+  year		  = {2009}
+}
+
+@Collection{britannica,
+  options	  = {useeditor=false},
+  label		  = {EB},
+  langid	  = {english},
+  langidopts = {variant=british},
+  sorttitle	  = {Encyclop{\ae}dia Britannica},
+  editor	  = {Preece, Warren E.},
+  indextitle	  = {Encyclop{\ae}dia Britannica, The New},
+  title		  = {The New Encyclop{\ae}dia Britannica},
+  shorttitle	  = {Encyclop{\ae}dia Britannica},
+  volumes	  = {32},
+  edition	  = {15},
+  publisher	  = {Encyclop{\ae}dia Britannica},
+  location	  = {Chicago, Ill.},
+  year		  = {2003},
+  annotation	  = {This is a \texttt{collection} entry for an encyclopedia. Note the
+		    \texttt{useeditor} option in the \texttt{options} field as well as the
+		    \texttt{sorttitle} field. We want this entry to be cited and alphabetized by
+		    title even though there is an editor. In addition to that, we want the title to
+		    be alphabetized under \enquote*{E} rather than \enquote*{T}. Also note the
+		    \texttt{label} field which is provided for author-year citation styles}
+}
+
+@Collection{gaonkar,
+  langid	  = {english},
+  langidopts = {variant=american},
+  editor	  = {Gaonkar, Dilip Parameshwar},
+  title		  = {Alternative Modernities},
+  publisher	  = {Duke University Press},
+  location	  = {Durham and London},
+  year		  = {2001},
+  isbn		  = {0-822-32714-7},
+  annotation	  = {This is a \texttt{collection} entry. Note the format of the \texttt{location}
+		    field in the database file as well as the \texttt{isbn} field}
+}
+
+@Collection{jaffe,
+  editor	  = {Jaff{\'e}, Philipp},
+  editora	  = {Loewenfeld, Samuel and Kaltenbrunner, Ferdinand and Ewald, Paul},
+  editoratype     = {redactor},
+  indextitle	  = {Regesta Pontificum Romanorum},
+  title		  = {Regesta Pontificum Romanorum ab condita ecclesia ad annum post Christum natum
+		    \textsc{mcxcviii}},
+  shorttitle	  = {Regesta Pontificum Romanorum},
+  volumes	  = {2},
+  edition	  = {2},
+  location	  = {Leipzig},
+  date		  = {1885/1888},
+  annotation	  = {A \texttt{collection} entry with \texttt{edition} and \texttt{volumes} fields.
+		    Note the \texttt{editortype} field handling the redactor}
+}
+
+@Collection{westfahl:frontier,
+  langid	  = {english},
+  langidopts = {variant=american},
+  editor	  = {Westfahl, Gary},
+  title		  = {Space and Beyond},
+  subtitle	  = {The Frontier Theme in Science Fiction},
+  booktitle	  = {Space and Beyond},
+  booksubtitle	  = {The Frontier Theme in Science Fiction},
+  publisher	  = {Greenwood},
+  location	  = {Westport, Conn. and London},
+  year		  = {2000},
+  annotation	  = {This is a \texttt{collection} entry. Note the format of the \texttt{location}
+		    field as well as the \texttt{subtitle} and \texttt{booksubtitle} fields}
+}
+
+@InBook{kant:kpv,
+  shorthand	  = {KpV},
+  langid	  = {german},
+  author	  = {Kant, Immanuel},
+  bookauthor	  = {Kant, Immanuel},
+  title		  = {Kritik der praktischen Vernunft},
+  shorttitle	  = {Kritik der praktischen Vernunft},
+  booktitle	  = {Kritik der praktischen Vernunft. Kritik der Urtheilskraft},
+  maintitle	  = {Kants Werke. Akademie Textausgabe},
+  volume	  = {5},
+  publisher	  = {Walter de Gruyter},
+  location	  = {Berlin},
+  year		  = {1968},
+  pages		  = {1--163},
+  annotation	  = {An edition of Kant's \emph{Collected Works}, volume five. This is an
+		    \texttt{inbook} entry which explicitly refers to the \emph{Critique of Practical
+		    Reason} only, not to the entire fifth volume. Note the \texttt{author} and
+		    \texttt{bookauthor} fields in the database file. By default, the
+		    \texttt{bookauthor} is omitted if the values of the \texttt{author} and
+		    \texttt{bookauthor} fields are identical}
+}
+
+@InBook{kant:ku,
+  shorthand	  = {KU},
+  langid	  = {german},
+  author	  = {Kant, Immanuel},
+  bookauthor	  = {Kant, Immanuel},
+  title		  = {Kritik der Urtheilskraft},
+  booktitle	  = {Kritik der praktischen Vernunft. Kritik der Urtheilskraft},
+  maintitle	  = {Kants Werke. Akademie Textausgabe},
+  volume	  = {5},
+  publisher	  = {Walter de Gruyter},
+  location	  = {Berlin},
+  year		  = {1968},
+  pages		  = {165--485},
+  annotation	  = {An edition of Kant's \emph{Collected Works}, volume five. This is an
+		    \texttt{inbook} entry which explicitly refers to the \emph{Critique of Judgment}
+		    only, not to the entire fifth volume}
+}
+
+@InBook{nietzsche:historie,
+  langid	  = {german},
+  sortyear	  = {1988-01-243},
+  sorttitle	  = {Werke-01-243},
+  indexsorttitle  = {Vom Nutzen und Nachtheil der Historie fur das Leben},
+  author	  = {Nietzsche, Friedrich},
+  bookauthor	  = {Nietzsche, Friedrich},
+  editor	  = {Colli, Giorgio and Montinari, Mazzino},
+  indextitle	  = {Vom Nutzen und Nachtheil der Historie f{\"u}r das Leben},
+  title		  = {Unzeitgem{\"a}sse Betrachtungen. Zweites St{\"u}ck},
+  subtitle	  = {Vom Nutzen und Nachtheil der Historie f{\"u}r das Leben},
+  shorttitle	  = {Vom Nutzen und Nachtheil der Historie},
+  booktitle	  = {Die Geburt der Trag{\"o}die. Unzeitgem{\"a}{\ss}e Betrachtungen I--IV.
+		    Nachgelassene Schriften 1870--1973},
+  maintitle	  = {S{\"a}mtliche Werke},
+  mainsubtitle	  = {Kritische Studienausgabe},
+  volume	  = {1},
+  publisher	  = dtv # { and Walter de Gruyter},
+  location	  = {M{\"u}nchen and Berlin and New York},
+  year		  = {1988},
+  pages		  = {243--334},
+  annotation	  = {A single essay from the critical edition of Nietzsche's works. This
+		    \texttt{inbook} entry explicitly refers to an essay found in the first volume.
+		    Note the \texttt{title}, \texttt{booktitle}, and \texttt{maintitle} fields. Also
+		    note the \texttt{sorttitle} and \texttt{sortyear} fields. We want this entry to
+		    be listed after the entry referring to the entire first volume}
+}
+
+@InCollection{brandt,
+  options	  = {useprefix=false},
+  langid	  = {german},
+  indexsorttitle  = {Nordischen Lander von der Mitte des 11. Jahrhunderts bis 1448},
+  author	  = {von Brandt, Ahasver and Erich Hoffmann},
+  editor	  = {Ferdinand Seibt},
+  indextitle	  = {Nordischen L{\"a}nder von der Mitte des 11.~Jahrhunderts bis 1448, Die},
+  title		  = {Die nordischen L{\"a}nder von der Mitte des 11.~Jahrhunderts bis 1448},
+  shorttitle	  = {Die nordischen L{\"a}nder},
+  booktitle	  = {Europa im Hoch- und Sp{\"a}tmittelalter},
+  series	  = {Handbuch der europ{\"a}ischen Geschichte},
+  number	  = {2},
+  publisher	  = {Klett-Cotta},
+  location	  = {Stuttgart},
+  year		  = {1987},
+  pages		  = {884--917},
+  annotation	  = {An \texttt{incollection} entry with a \texttt{series} and a \texttt{number}.
+		    Note the format of the printed name and compare the \texttt{useprefix} option in
+		    the \texttt{options} field as well as \texttt{vangennep}. Also note the
+		    \texttt{indextitle, and \texttt{indexsorttitle} fields}}
+}
+
+@InCollection{hyman,
+  keywords	  = {secondary},
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Arthur Hyman},
+  editor	  = {O'Meara, Dominic J.},
+  indextitle	  = {Aristotle's Theory of the Intellect},
+  title		  = {Aristotle's Theory of the Intellect and its Interpretation by Averroes},
+  shorttitle	  = {Aristotle's Theory of the Intellect},
+  booktitle	  = {Studies in Aristotle},
+  series	  = {Studies in Philosophy and the History of Philosophy},
+  number	  = {9},
+  publisher	  = {The Catholic University of America Press},
+  location	  = {Washington, D.C.},
+  year		  = {1981},
+  pages		  = {161--191},
+  annotation	  = {An \texttt{incollection} entry with a \texttt{series} and \texttt{number} field}
+}
+
+@InCollection{pines,
+  keywords	  = {secondary},
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Pines, Shlomo},
+  editor	  = {Twersky, Isadore},
+  indextitle	  = {Limitations of Human Knowledge According to Al-Farabi, ibn Bajja, and
+		    Maimonides, The},
+  title		  = {The Limitations of Human Knowledge According to Al-Farabi, ibn Bajja, and
+		    Maimonides},
+  shorttitle	  = {Limitations of Human Knowledge},
+  booktitle	  = {Studies in Medieval Jewish History and Literature},
+  publisher	  = hup,
+  location	  = {Cambridge, Mass.},
+  year		  = {1979},
+  pages		  = {82--109},
+  annotation	  = {A typical \texttt{incollection} entry. Note the \texttt{indextitle} field}
+}
+
+@InProceedings{moraux,
+  keywords	  = {secondary},
+  langid	  = {french},
+  indexsorttitle  = {De Anima dans la tradition grecque},
+  author	  = {Moraux, Paul},
+  editor	  = {Lloyd, G. E. R. and Owen, G. E. L.},
+  indextitle	  = {\emph{De Anima} dans la tradition gr{\`e}cque, Le},
+  title		  = {Le \emph{De Anima} dans la tradition gr{\`e}cque},
+  subtitle	  = {Quelques aspects de l'interpretation du trait{\'e}, de Theophraste {\`a}
+		    Themistius},
+  shorttitle	  = {\emph{De Anima} dans la tradition gr{\`e}cque},
+  booktitle	  = {Aristotle on Mind and the Senses},
+  booktitleaddon  = {Proceedings of the Seventh Symposium Aristotelicum (1975)},
+  publisher	  = cup,
+  location	  = {Cambridge},
+  date		  = {1979-01-02/1980-04-08},
+  origdate        = {1924-06-07/1924-07-09},
+  eventdate       = {1924-02-03/1924-02-05},
+  urldate         = {1979-03-03/1979-03-04},
+  url             = {http://some/thing},
+  pages		  = {281--324},
+  annotation	  = {This is a typical \texttt{inproceedings} entry. Note the \texttt{booksubtitle},
+		    \texttt{shorttitle}, \texttt{indextitle}, and \texttt{indexsorttitle} fields}
+}
+
+@InProceedings{stdmodel:salam,
+  entryset	  = {stdmodel},
+  author	  = {Salam, Abdus},
+  editor	  = {Svartholm, Nils},
+  title		  = {Weak and Electromagnetic Interactions},
+  booktitle	  = {Elementary particle theory},
+  booksubtitle	  = {Relativistic groups and analyticity},
+  booktitleaddon  = {Proceedings of the Eighth Nobel Symposium, May 19--25, 1968},
+  venue		  = {Aspen{\"a}sgarden, Lerum},
+  publisher	  = {Almquist \& Wiksell},
+  location	  = {Stockholm},
+  year		  = {1968},
+  pages		  = {367\psqq}
+}
+
+@Manual{cms,
+  label		  = {CMS},
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {Chicago Manual of Style},
+  indextitle	  = {Chicago Manual of Style, The},
+  title		  = {The Chicago Manual of Style},
+  subtitle	  = {The Essential Guide for Writers, Editors, and Publishers},
+  shorttitle	  = {Chicago Manual of Style},
+  edition	  = {15},
+  publisher	  = {University of Chicago Press},
+  location	  = {Chicago, Ill.},
+  year		  = {2003},
+  isbn		  = {0-226-10403-6},
+  annotation	  = {This is a \texttt{manual} entry without an \texttt{author} or \texttt{editor}.
+		    Note the \texttt{label} field in the database file which is provided for
+		    author-year citation styles. Also note the \texttt{sorttitle} and
+		    \texttt{indextitle} fields. By default, all entries without an \texttt{author}
+		    or \texttt{editor} are alphabetized by \texttt{title} but we want this entry to
+		    be alphabetized under \enquote*{C} rather than \enquote*{T}. There's also an
+		    \texttt{isbn} field}
+}
+
+@Online{baez/online,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Baez, John C. and Lauda, Aaron D.},
+  title		  = {Higher-Dimensional Algebra V: 2-Groups},
+  version	  = {3},
+  date		  = {2004-10-27},
+  eprint	  = {math/0307200v3},
+  eprinttype	  = {arxiv},
+  annotation	  = {An \texttt{online} reference from arXiv. Note the \texttt{eprint} and
+		    \texttt{eprinttype} fields. Also note that the arXiv reference is transformed
+		    into a clickable link if \texttt{hyperref} support has been enabled. Compare
+		    \texttt{baez\slash article} which is the same item given as an \texttt{article}
+		    entry with eprint information}
+}
+
+@Online{ctan,
+  label		  = {CTAN},
+  langid	  = {english},
+  langidopts = {variant=american},
+  title		  = {CTAN},
+  subtitle	  = {The Comprehensive TeX Archive Network},
+  year		  = {2006},
+  url		  = {http://www.ctan.org},
+  urldate	  = {2006-10-01},
+  annotation	  = {This is an \texttt{online} entry. The \textsc{url}, which is given in the
+		    \texttt{url} field, is transformed into a clickable link if \texttt{hyperref}
+		    support has been enabled. Note the format of the \texttt{urldate} field
+		    (\texttt{yyyy-mm-dd}) in the database file. It is also possible to use the
+		    fields \texttt{urlday}\slash \texttt{urlmonth}\slash \texttt{urlyear} instead.
+		    Also note the \texttt{label} field which may be used as a fallback by citation
+		    styles which need an \texttt{author} and\slash or a \texttt{year}}
+}
+
+@Online{itzhaki,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Itzhaki, Nissan},
+  title		  = {Some remarks on 't Hooft's S-matrix for black holes},
+  version	  = {1},
+  date		  = {1996-03-11},
+  eprint	  = {hep-th/9603067},
+  eprinttype	  = {arxiv},
+  annotation	  = {An \texttt{online} reference from arXiv. Note the \texttt{eprint} and
+		    \texttt{eprinttype} fields. Also note that the arXiv reference is transformed
+		    into a clickable link if \texttt{hyperref} support has been enabled},
+  abstract	  = {We discuss the limitations of 't Hooft's proposal for the black hole S-matrix.
+		    We find that the validity of the S-matrix implies violation of the
+		    semi-classical approximation at scales large compared to the Planck scale. We
+		    also show that the effect of the centrifugal barrier on the S-matrix is crucial
+		    even for large transverse distances.}
+}
+
+@Online{markey,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {Tame the Beast},
+  author	  = {Markey, Nicolas},
+  title		  = {Tame the BeaST},
+  subtitle	  = {The B to X of BibTeX},
+  version	  = {1.3},
+  url		  = {http://tug.ctan.org/tex-archive/info/bibtex/tamethebeast/ttb_en.pdf},
+  urldate	  = {2006-10-01},
+  annotation	  = {An \texttt{online} entry for a tutorial. Note the format of the \texttt{date}
+		    field (\texttt{yyyy-mm-dd}) in the database file. It is also possible to use the
+		    fields \texttt{day}\slash \texttt{month}\slash \texttt{year} instead.}
+}
+
+@Patent{almendro,
+  langid	  = {german},
+  author	  = {Almendro, Jos{\'e} L. and Mart{\'i}n, Jacinto and S{\'a}nchez, Alberto and
+		    Nozal, Fernando},
+  title		  = {Elektromagnetisches Signalhorn},
+  number	  = {EU-29702195U},
+  location	  = {countryes and countryfr and countryuk and countryde},
+  year		  = {1998},
+  annotation	  = {This is a \texttt{patent} entry with a \texttt{location} field. The number is
+		    given in the \texttt{number} field. Note the format of the \texttt{location}
+		    field in the database file. Compare \texttt{laufenberg}, \texttt{sorace}, and
+		    \texttt{kowalik}}
+}
+
+@Patent{kowalik,
+  langid	  = {french},
+  author	  = {Kowalik, F. and Isard, M.},
+  indextitle	  = {Estimateur d'un d{\'e}faut de fonctionnement},
+  title		  = {Estimateur d'un d{\'e}faut de fonctionnement d'un modulateur en quadrature et
+		    {\'e}tage de modulation l'utilisant},
+  type		  = {patreqfr},
+  number	  = {9500261},
+  date		  = {1995-01-11},
+  annotation	  = {This is a \texttt{patent} entry for a French patent request with a full date.
+		    The number is given in the \texttt{number} field. Note the format of the
+		    \texttt{type} and \texttt{date} fields in the database file. Compare
+		    \texttt{almendro}, \texttt{laufenberg}, and \texttt{sorace}}
+}
+
+@Patent{laufenberg,
+  langid	  = {german},
+  author	  = {Laufenberg, Xaver and Eynius, Dominique and Suelzle, Helmut and Usbeck, Stephan
+		    and Spaeth, Matthias and Neuser-Hoffmann, Miriam and Myrzik, Christian and
+		    Schmid, Manfred and Nietfeld, Franz and Thiel, Alexander and Braun, Harald and
+		    Ebner, Norbert},
+  holder	  = {{Robert Bosch GmbH} and {Daimler Chrysler AG} and {Bayerische Motoren Werke
+		    AG}},
+  title		  = {Elektrische Einrichtung und Betriebsverfahren},
+  type		  = {patenteu},
+  number	  = {1700367},
+  location	  = {countryde and countrywo},
+  date		  = {2006-09-13},
+  annotation	  = {This is a \texttt{patent} entry with a \texttt{holder} field. Note the format
+		    of the \texttt{type} and \texttt{location} fields in the database file. Compare
+		    \texttt{almendro}, \texttt{sorace}, and \texttt{kowalik}},
+  abstract	  = {The invention relates to an electric device comprising a generator, in
+		    particular for use in the vehicle electric system of a motor vehicle and a
+		    controller for controlling the generator voltage. The device is equipped with a
+		    control zone, in which the voltage is controlled and zones, in which the torque
+		    is controlled. The invention also relates to methods for operating a device of
+		    this type.},
+  file		  = {http://v3.espacenet.com/textdoc?IDX=EP1700367}
+}
+
+@Patent{sorace,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Sorace, Ronald E. and Reinhardt, Victor S. and Vaughn, Steven A.},
+  holder	  = {{Hughes Aircraft Company}},
+  title		  = {High-Speed Digital-to-RF Converter},
+  type		  = {patentus},
+  number	  = {5668842},
+  date		  = {1997-09-16},
+  annotation	  = {This is a \texttt{patent} entry with a \texttt{holder} field. Note the format
+		    of the \texttt{type} and \texttt{date} fields in the database file. Compare
+		    \texttt{almendro}, \texttt{laufenberg}, and \texttt{kowalik}}
+}
+
+@Report{chiu,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {Hybrid Hierarchical Model of a Multiple Virtual Storage (MVS) Operating
+		    System},
+  author	  = {Chiu, Willy W. and Chow, We Min},
+  indextitle	  = {Hybrid Hierarchical Model, A},
+  title		  = {A Hybrid Hierarchical Model of a Multiple Virtual Storage (MVS) Operating
+		    System},
+  institution	  = {IBM and HP and Sun and Sony},
+  type		  = {resreport},
+  number	  = {RC-6947},
+  year		  = {1978},
+  annotation	  = {This is a \texttt{report} entry for a research report. Note the format of the
+		    \texttt{type} field in the database file which uses a localization key. The
+		    number of the report is given in the \texttt{number} field. Also note the
+		    \texttt{sorttitle} and \texttt{indextitle} fields}
+}
+
+@Report{padhye,
+  langid	  = {english},
+  langidopts = {variant=american},
+  sorttitle	  = {A Stochastic Model of TCP Reno Congestion Avoidance and Control},
+  author	  = {Padhye, Jitendra and Firoiu, Victor and Towsley, Don},
+  indextitle	  = {Stochastic Model of TCP Reno Congestion Avoidance and Control, A},
+  title		  = {A Stochastic Model of TCP Reno Congestion Avoidance and Control},
+  institution	  = {University of Massachusetts},
+  type		  = {techreport},
+  number	  = {99-02},
+  location	  = {Amherst, Mass.},
+  year		  = {1999},
+  annotation	  = {This is a \texttt{report} entry for a technical report. Note the format of the
+		    \texttt{type} field in the database file which uses a localization key. The
+		    number of the report is given in the \texttt{number} field. Also note the
+		    \texttt{sorttitle} and \texttt{indextitle} fields},
+  abstract	  = {The steady state performance of a bulk transfer TCP flow (i.e. a flow with a
+		    large amount of data to send, such as FTP transfers) may be characterized by
+		    three quantities. The first is the send rate, which is the amount of data sent
+		    by the sender in unit time. The second is the throughput, which is the amount of
+		    data received by the receiver in unit time. Note that the throughput will always
+		    be less than or equal to the send rate due to losses. Finally, the number of
+		    non-duplicate packets received by the receiver in unit time gives us the goodput
+		    of the connection. The goodput is always less than or equal to the throughput,
+		    since the receiver may receive two copies of the same packet due to
+		    retransmissions by the sender. In a previous paper, we presented a simple model
+		    for predicting the steady state send rate of a bulk transfer TCP flow as a
+		    function of loss rate and round trip time. In this paper, we extend that work in
+		    two ways. First, we analyze the performance of bulk transfer TCP flows using
+		    more precise, stochastic analysis. Second, we build upon the previous analysis
+		    to provide both an approximate formula as well as a more accurate stochastic
+		    model for the steady state throughput of a bulk transfer TCP flow.},
+  file		  = {ftp://gaia.cs.umass.edu/pub/Padhey99-markov.ps}
+}
+
+@Thesis{geer,
+  options	  = {useprefix=false},
+  langid	  = {english},
+  langidopts = {variant=british},
+  author	  = {de Geer, Ingrid},
+  title		  = {Earl, Saint, Bishop, Skald~-- and Music},
+  subtitle	  = {The Orkney Earldom of the Twelfth Century. A Musicological Study},
+  institution	  = {Uppsala Universitet},
+  type		  = {phdthesis},
+  location	  = {Uppsala},
+  year		  = {1985},
+  annotation	  = {This is a typical \texttt{thesis} entry for a PhD thesis. Note the
+		    \texttt{type} field in the database file which uses a localization key. Also
+		    note the format of the printed name and compare the \texttt{useprefix} option in
+		    the \texttt{options} field as well as \texttt{vangennep}}
+}
+
+@Thesis{loh,
+  langid	  = {english},
+  langidopts = {variant=american},
+  author	  = {Loh, Nin C.},
+  title		  = {High-Resolution Micromachined Interferometric Accelerometer},
+  institution	  = {Massachusetts Institute of Technology},
+  type		  = {mathesis},
+  location	  = {Cambridge, Mass.},
+  year		  = {1992},
+  annotation	  = {This is a typical \texttt{thesis} entry for an MA thesis. Note the
+		    \texttt{type} field in the database file which uses a localization key}
+}
+
+@Thesis{Pimentel00,
+  author          = {Pimentel, Jr.,Joseph J.},
+  title           = {Sociolinguistic Reflections of Privatization and Globalization: The {Arabic} of {Egyptian} newspaper advertisements},
+  school          = {University of Michigan},
+  year            = {2000},
+}
+
+@Book{luzzatto,
+  author	   = {Luzzatto, Moshe Ḥayyim},
+  title		   = {ha-Lashon la-Ramḥal: u-vo sheloshah ḥiburim},
+  location   = {Yerushalayim},
+  publisher  = {Makhon Ramḥal},
+  year		   = {2000}
+}
+
+% Without braces round this prefixed lastname, T::B::N fails to get
+% the lastname on Windows for some reason
+@BOOK{hasan,
+  author	   = {{al-Hasan}, ʿAlī},
+  editor	   = {{al-Hasan}, ʿAlī},
+  translator = {{al-Hasan}, ʿAlī},
+  title		   = {Some title},
+  publisher  = {Some press},
+  year		   = {2000},
+}
+
+% This also tests auto-escaping of some LaTeX specials chars like "%"
+@MISC{t1,
+  KEYWORDS	= { primary, something,somethingelse},
+  AUTHOR = {Bill Brown},
+  TITLE = {10\% of [100] and 90% of $Normal_2$ | \& # things {$^{3}$}},
+  YEAR = 1992,
+  PAGES = {100--}
+}
+
+% SORTNAME should not be output
+@MISC{t2,
+  AUTHOR = {Bill Brown},
+  SORTNAME = {Bill Brown},
+  TITLE = {Signs of W$\frac{o}{a}$nder},
+  YEAR = {1994},
+  PAGES = {100--108}
+}
+
+@MISC{tvonb,
+  AUTHOR = {Terrence von Bobble},
+  TITLE = {Things},
+  YEAR = {1997}
+}
+
+% fullhash and namehash should be different for these two
+@UNPUBLISHED{anon1,
+  AUTHOR = {AnonymousX},
+  TITLE = {Title1},
+  YEAR = {1835},
+  SHORTAUTHOR = {XAnony},
+  SHORTTITLE = {Shorttitle},
+  KEYWORDS = {arc},
+  PAGES = {111--118},
+  LANGID	  = {english},
+  LANGIDOPTS = {variant=american},
+}
+
+@UNPUBLISHED{anon2,
+  AUTHOR = {AnonymousY},
+  TITLE = {Title2},
+  YEAR = {1839},
+  PAGES = {1176--1276},
+  SHORTAUTHOR = {YAnony},
+  SHORTTITLE = {Shorttitle},
+  KEYWORDS = {arc},
+  LANGID	  = {en},
+  LANGIDOPTS = {variant=american},
+}
+
+% Testing uniquelist
+
+@MISC{u1,
+  AUTHOR = {AAA and BBB and CCC and DDD},
+  TITLE  = {A title},
+  DATE   = {2000}
+}
+
+@MISC{u2,
+  AUTHOR = {AAA and BBB and CCC and DDD and EEE},
+  TITLE  = {A title},
+  DATE   = {2003}
+}
+
+% Testing ignore
+
+@UNPUBLISHED{i1,
+  ABSTRACT = {Some abstract %50 of which is useless},
+  AUTHOR = {AAA and BBB and CCC and DDD and EEE},
+  TITLE  = {A title},
+  DATE   = {2003},
+  USERB  = {test},
+  LISTA  = {list test},
+  LISTB  = {late and early},
+  LISTC  = {late and early},
+  LISTD  = {æøå},
+}
+
+@MISC{i2,
+  USERB = {Some text & some bad chars},
+  USERF = {Something to lose in an alsoset},
+  AUTHOR = {AAA and BBB and CCC},
+  TITLE  = {A title},
+  DATE   = {2005}
+}
+
+% Testing per_type and per_entry max/min*names
+
+@MISC{tmn1,
+  AUTHOR = {AAA and BBB and CCC},
+  TITLE  = {A title},
+  INSTITUTION = {A and B and C},
+  DATE   = {2005}
+}
+
+@BOOK{tmn2,
+  OPTIONS = {maxalphanames = 2},
+  AUTHOR = {AAA and BBB and CCC},
+  TITLE  = {A title},
+  DATE   = {2005}
+}
+
+@UNPUBLISHED{tmn3,
+  OPTIONS = {minitems=2},
+  AUTHOR = {AAA and BBB and CCC},
+  INSTITUTION = {A and B and C},
+  TITLE  = {A title},
+  DATE   = {2005}
+}
+
+@UNPUBLISHED{tmn4,
+  OPTIONS = {maxbibnames=4},
+  AUTHOR = {AAA and BBB and CCC},
+  TITLE  = {A title},
+  DATE   = {2005}
+}
+
+% Test of duplicate skipping
+@UNPUBLISHED{tmn4,
+  AUTHOR = {ZZZ}
+}
+
+% Testing exotic labelnames
+@MISC{lne1,
+  AUTHOR = {AAA and BBB and CCC},
+  NAMEA = {ZZZ},
+  TITLE  = {A title},
+  DATE   = {2005}
+}
+
+% Testing citekey aliases
+@MISC{alias1,
+  AUTHOR = {Alan Alias},
+  DATE   = {2005},
+  IDS    = {alias2, alias3}
+}
+
+@MISC{alias2,
+  AUTHOR = {Alan Alias},
+  DATE   = {2005},
+  IDS    = {alias4}
+}
+
+@MISC{alias5,
+  AUTHOR = {Alan Alias},
+  DATE   = {2005},
+  IDS    = {alias6}
+}
+
+% Testing url encoding
+@MISC{url1,
+  AUTHOR = {Alan Alias},
+  DATE   = {2005},
+  URL = {http://www.something.com/q=á\'{e}\'aŠ},
+  URLS = {http://www.something.com/q=á\'{e}\'aŠ and http://www.sun.com}
+}
+
+@MISC{url2,
+  AUTHOR = {Alan Alias},
+  DATE   = {2005},
+  URL = {http://www.something.com/q=one\%20two}
+}
+
+@ONLINE{ol1,
+  AUTHOR = {Oliver Online},
+  TITLE = {Online1},
+  NOTE = {A note}
+}
+
+@MISC{pages1,
+  PAGES = {23--24}
+}
+
+@MISC{pages2,
+  PAGES = {23}
+}
+
+@MISC{pages3,
+  PAGES = {{I-II}---{III-IV}}
+}
+
+@MISC{pages4,
+  PAGES = { 3 -- 5 },
+}
+
+@MISC{pages5,
+  PAGES = {42--},
+}
+
+@MISC{pages6,
+  PAGES = {\bibstring{number} 42},
+}
+
+@MISC{pages7,
+  PAGES = {\bibstring{number} 42, 3 --- 6, {I-II}--5},
+}
+
+@MISC{pages8,
+  PAGES = {10-15, ⅥⅠ-ⅻ},
+}
+
+@MISC{pages9,
+  PAGES = {M-1--M-4},
+}
+
+
+% Testing user->style maps
+@CONVERSATION{us1,
+  AUTHOR = {Test},
+}
+
+@BOOK{labelstest,
+  AUTHOR = {AAA and BBB and CCC},
+  TITLE  = {A title},
+  DATE   = {2005-03-02}
+}
+
+@BOOK{list1,
+  LOCATION = {AAA and BBB and others}
+}
+
+@BOOK{sn1,
+  SORTNAME = {ZZZ},
+  AUTHOR = {AAA}
+}
+

--- a/bibtexparser/tests/data/crossref_cascading.bib
+++ b/bibtexparser/tests/data/crossref_cascading.bib
@@ -1,0 +1,23 @@
+% From biber test data : t/tdata/crossrefs.bib
+% Kept initial comment but not for our purpose
+
+% Test of dependency calculations for non-cited entries
+
+@BOOK{r1,
+  DATE      = {1911},
+  CROSSREF  = {r2}
+}
+
+@BOOK{r2,
+  DATE      = {1911},
+  CROSSREF  = {r3}
+}
+
+@BOOK{r3,
+  DATE      = {1911},
+  CROSSREF  = {r4}
+}
+
+@BOOK{r4,
+  DATE      = {1911},
+}

--- a/bibtexparser/tests/data/crossref_cascading_aliases.bib
+++ b/bibtexparser/tests/data/crossref_cascading_aliases.bib
@@ -1,0 +1,24 @@
+% From biber test data : t/tdata/crossrefs.bib
+% Kept initial comment but not for our purpose
+
+% Testing cascading crossrefs
+@MVBOOK{ccr1,
+  IDS       = {ccr1alias},
+  AUTHOR    = {Vince Various},
+  EDITOR    = {Edward Editor},
+  TITLE     = {Stuff Concerning Varia},
+  DATE      = {1934}
+}
+
+% using alias
+@BOOK{ccr2,
+  TITLE     = {Misc etc.},
+  DATE      = {1923},
+  CROSSREF  = {ccr1alias}
+}
+
+@INBOOK{ccr3,
+  TITLE     = {Perhaps, Perchance, Possibilities?},
+  DATE      = {1911},
+  CROSSREF  = {ccr2}
+}

--- a/bibtexparser/tests/data/crossref_cascading_cycle.bib
+++ b/bibtexparser/tests/data/crossref_cascading_cycle.bib
@@ -1,0 +1,19 @@
+% From biber test data : t/tdata/crossrefs.bib
+% Kept initial comment but not for our purpose
+
+% Testing circular refs detection
+
+@BOOK{circ1,
+  DATE      = {1911},
+  CROSSREF  = {circ3}
+}
+
+@BOOK{circ2,
+  DATE      = {1911},
+  CROSSREF  = {circ1}
+}
+
+@BOOK{circ3,
+  DATE      = {1911},
+  CROSSREF  = {circ2}
+}

--- a/bibtexparser/tests/data/crossref_cascading_cycle.bib
+++ b/bibtexparser/tests/data/crossref_cascading_cycle.bib
@@ -5,15 +5,10 @@
 
 @BOOK{circ1,
   DATE      = {1911},
-  CROSSREF  = {circ3}
+  CROSSREF  = {circ2}
 }
 
 @BOOK{circ2,
   DATE      = {1911},
   CROSSREF  = {circ1}
-}
-
-@BOOK{circ3,
-  DATE      = {1911},
-  CROSSREF  = {circ2}
 }

--- a/bibtexparser/tests/data/crossref_entries.bib
+++ b/bibtexparser/tests/data/crossref_entries.bib
@@ -1,0 +1,132 @@
+% From biber test data : t/tdata/crossrefs.bib
+% Kept initial comment but not for our purpose
+
+% Testing mincrossrefs. cr1 and cr2 crossrefs should trigger inclusion of cr_m and also
+% the crossref fields in both of them
+% Also a test of some aliases
+@INBOOK{cr1,
+  AUTHOR        = {Graham Gullam},
+  TITLE         = {Great and Good Graphs},
+  ORIGDATE      = {1955},
+  ARCHIVEPREFIX = {SomEPrFiX},
+  PRIMARYCLASS  = {SOMECLASS},
+  CROSSREF      = {cr_m}
+}
+
+@INBOOK{cr2,
+  AUTHOR      = {Frederick Fumble},
+  TITLE       = {Fabulous Fourier Forms},
+  SCHOOL      = {School},
+  INSTITUTION = {Institution},
+  ORIGDATE    = {1943},
+  CROSSREF    = {cr_m}
+}
+
+@BOOK{cr_m,
+  EDITOR    = {Edgar Erbriss},
+  TITLE     = {Graphs of the Continent},
+  PUBLISHER = {Grimble},
+  YEAR      = {1974}
+}
+
+% Testing explicit cite of crossref parent. Should trigger inclusion of child crossref field
+@INBOOK{cr3,
+  AUTHOR        = {Arthur Aptitude},
+  TITLE         = {Arrangements of All Articles},
+  ORIGDATE      = {1934},
+  ARCHIVEPREFIX = {SomEPrFiX},
+  EPRINTTYPE    = {sometype},
+  CROSSREF      = {crt}
+}
+
+@BOOK{crt,
+  EDITOR    = {Mark Monkley},
+  TITLE     = {Beasts of the Burbling Burns},
+  PUBLISHER = {Rancour},
+  YEAR      = {1996}
+}
+
+% Testing mincrossrefs not reached. cr4 is cited, cr5 isn't, therefore mincrossrefs (2) for
+% crn not reached
+@INBOOK{cr4,
+  AUTHOR    = {Morris Mumble},
+  TITLE     = {Enterprising Entities},
+  ORIGDATE  = {1911},
+  CROSSREF  = {crn}
+}
+
+@INBOOK{cr5,
+  AUTHOR    = {Oliver Ordinary},
+  TITLE     = {Questionable Quidities},
+  ORIGDATE  = {1919},
+  CROSSREF  = {crn}
+}
+
+@BOOK{crn,
+  EDITOR    = {Jeremy Jermain},
+  TITLE     = {Vanquished, Victor, Vandal},
+  PUBLISHER = {Pillsbury},
+  YEAR      = {1945}
+}
+
+% Testing inheritance of event information
+@PROCEEDINGS{cr6i,
+  AUTHOR     = {Spurious Author},
+  ADDRESS    = {Address},
+  TITLE      = {Title of proceeding},
+  EDITOR     = {Editor},
+  PUBLISHER  = {Publisher of proceeding},
+  EVENTDATE  = {2009-08-21/2009-08-24},
+  EVENTTITLE = {Title of the event},
+  VENUE      = {Location of event},
+  YEAR       = {2009}
+}
+
+@INPROCEEDINGS{cr6,
+  AUTHOR     = {Author, Firstname},
+  CROSSREF   = {cr6i},
+  PAGES      = {123--},
+  TITLE      = {Title of inproceeding},
+  BOOKTITLE  = {Manual booktitle},
+  YEAR       = {2009},
+}
+
+% Testing inheritance of special fields (booktitle, bookauthor etc.)
+@BOOK{cr7i,
+  AUTHOR     = {Brian Bookauthor},
+  TITLE      = {Book Title},
+  SUBTITLE   = {Book Subtitle},
+  TITLEADDON = {Book Titleaddon},
+  PUBLISHER  = {Publisher of proceeding},
+  YEAR       = {2009},
+  VERBA      = {String},
+}
+
+@INBOOK{cr7,
+  AUTHOR     = {Author, Firstname},
+  CROSSREF   = {cr7i},
+  PAGES      = {123--126},
+  TITLE      = {Title of Book bit},
+  YEAR       = {2010}
+}
+
+% Testing supression of default inheritance
+@COLLECTION{cr8i,
+  EDITOR     = {Brian Editor},
+  TITLE      = {Book Title},
+  SUBTITLE   = {Book Subtitle},
+  TITLEADDON = {Book Titleaddon},
+  PUBLISHER  = {Publisher of Collection},
+  YEAR       = {2009}
+}
+
+@INCOLLECTION{cr8,
+  AUTHOR     = {Smith, Firstname},
+  CROSSREF   = {cr8i},
+  PAGES      = {1--12},
+  TITLE      = {Title of Collection bit},
+  YEAR       = {2010}
+}
+
+
+

--- a/bibtexparser/tests/data/crossref_missing_entries.bib
+++ b/bibtexparser/tests/data/crossref_missing_entries.bib
@@ -1,0 +1,7 @@
+% Testing missing crossref
+@INBOOK{mcr,
+  AUTHOR    = {Megan Mistrel},
+  TITLE     = {Lumbering Lunatics},
+  ORIGDATE  = {1933},
+  CROSSREF  = {missing1}
+}

--- a/bibtexparser/tests/data/xref_entries.bib
+++ b/bibtexparser/tests/data/xref_entries.bib
@@ -1,0 +1,63 @@
+% From biber test data : t/tdata/crossrefs.bib
+% Kept initial comment but not for our purpose
+
+% Testing mincrossrefs. xr1 and xr2 xrefs should trigger inclusion of xrm and also
+% the xreffields in both of them
+@INBOOK{xr1,
+  AUTHOR    = {Zoe Zentrum},
+  TITLE     = {Moods Mildly Modified},
+  ORIGDATE  = {1921},
+  XREF      = {xrm}
+}
+
+@INBOOK{xr2,
+  AUTHOR    = {Ian Instant},
+  TITLE     = {Migraines Multiplying Madly},
+  ORIGDATE  = {1926},
+  XREF      = {xrm}
+}
+
+@BOOK{xrm,
+  EDITOR    = {Peter Prendergast},
+  TITLE     = {Calligraphy, Calisthenics, Culture},
+  PUBLISHER = {Mainstream},
+  YEAR      = {1970}
+}
+
+% Testing explicit cite of xref parent. Should trigger inclusion of child xref field
+@INBOOK{xr3,
+  AUTHOR    = {Norman Normal},
+  TITLE     = {Russian Regalia Revisited},
+  ORIGDATE  = {1923},
+  XREF      = {xrt}
+}
+
+@BOOK{xrt,
+  EDITOR    = {Lucy Lunders},
+  TITLE     = {Kings, Cork and Calculation},
+  PUBLISHER = {Middling},
+  YEAR      = {1977}
+}
+
+% Testing mincrossrefs not reached. cr4 is cited, cr5 isn't, therefore mincrossrefs (2) for
+% crn not reached
+@INBOOK{xr4,
+  AUTHOR    = {Megan Mistrel},
+  TITLE     = {Lumbering Lunatics},
+  ORIGDATE  = {1933},
+  XREF      = {xrn}
+}
+
+@INBOOK{xr5,
+  AUTHOR    = {Kenneth Kunrath},
+  TITLE     = {Dreadful Dreary Days},
+  ORIGDATE  = {1900},
+  XREF      = {xrn}
+}
+
+@BOOK{xrn,
+  EDITOR    = {Victor Vivacious},
+  TITLE     = {Examples of Excellent Exaggerations},
+  PUBLISHER = {Oxford},
+  YEAR      = {1935}
+}

--- a/bibtexparser/tests/data/xref_missing_entries.bib
+++ b/bibtexparser/tests/data/xref_missing_entries.bib
@@ -1,0 +1,10 @@
+% From biber test data : t/tdata/crossrefs.bib
+% Kept initial comment but not for our purpose
+
+% Testing missing xref
+@INBOOK{mxr,
+  AUTHOR    = {Megan Mistrel},
+  TITLE     = {Lumbering Lunatics},
+  ORIGDATE  = {1933},
+  XREF      = {missing1}
+}

--- a/bibtexparser/tests/test_crossref_resolving.py
+++ b/bibtexparser/tests/test_crossref_resolving.py
@@ -189,23 +189,18 @@ class TestCrossRef(unittest.TestCase):
         entries_expected = {'circ1': {'ENTRYTYPE': 'book',
                                       'ID': 'circ1',
                                       '_FROM_CROSSREF': [],
-                                      'crossref': 'circ3',
+                                      'crossref': 'circ2',
                                       'date': '1911'},
                             'circ2': {'ENTRYTYPE': 'book',
                                       'ID': 'circ2',
                                       '_FROM_CROSSREF': [],
                                       'crossref': 'circ1',
-                                      'date': '1911'},
-                            'circ3': {'ENTRYTYPE': 'book',
-                                      'ID': 'circ3',
-                                      '_FROM_CROSSREF': [],
-                                      'crossref': 'circ2',
                                       'date': '1911'}}
         parser = BibTexParser(add_missing_from_crossref=True)
         with self.assertLogs('bibtexparser.bibdatabase', level='ERROR') as cm:
             with open(input_file_path) as bibtex_file:
                 bibtex_database = parser.parse_file(bibtex_file)
-            self.assertIn("ERROR:bibtexparser.bibdatabase:Circular crossref dependency: circ1->circ3->circ2->circ1.", cm.output)
+            self.assertIn("ERROR:bibtexparser.bibdatabase:Circular crossref dependency: circ1->circ2->circ1.", cm.output)
         self.assertDictEqual(bibtex_database.entries_dict, entries_expected)
 
     def test_crossref_missing_entries(self):

--- a/bibtexparser/tests/test_crossref_resolving.py
+++ b/bibtexparser/tests/test_crossref_resolving.py
@@ -153,7 +153,7 @@ class TestCrossRef(unittest.TestCase):
                                     'publisher': 'Rancour',
                                     'title': 'Beasts of the Burbling Burns',
                                     'year': '1996'}}
-        parser = BibTexParser(add_missing_field_from_crossref=True, ignore_nonstandard_types=False)
+        parser = BibTexParser(add_missing_from_crossref=True, ignore_nonstandard_types=False)
         with open(input_file_path) as bibtex_file:
             bibtex_database = parser.parse_file(bibtex_file)
         self.assertDictEqual(bibtex_database.entries_dict, entries_expected)
@@ -178,12 +178,12 @@ class TestCrossRef(unittest.TestCase):
                             'r4': {'ENTRYTYPE': 'book',
                                    'ID': 'r4',
                                    'date': '1911'}}
-        
-        parser = BibTexParser(add_missing_field_from_crossref=True)
+
+        parser = BibTexParser(add_missing_from_crossref=True)
         with open(input_file_path) as bibtex_file:
             bibtex_database = parser.parse_file(bibtex_file)
         self.assertDictEqual(bibtex_database.entries_dict, entries_expected)
-        
+
     def test_crossref_cascading_cycle(self):
         input_file_path = 'bibtexparser/tests/data/crossref_cascading_cycle.bib'
         entries_expected = {'circ1': {'ENTRYTYPE': 'book',
@@ -201,13 +201,13 @@ class TestCrossRef(unittest.TestCase):
                                       '_FROM_CROSSREF': [],
                                       'crossref': 'circ2',
                                       'date': '1911'}}
-        parser = BibTexParser(add_missing_field_from_crossref=True)
+        parser = BibTexParser(add_missing_from_crossref=True)
         with self.assertLogs('bibtexparser.bibdatabase', level='ERROR') as cm:
             with open(input_file_path) as bibtex_file:
                 bibtex_database = parser.parse_file(bibtex_file)
-            self.assertIn("ERROR:bibtexparser.bibdatabase:Circular crossref dependance : circ1->circ3->circ2->circ1.", cm.output)
+            self.assertIn("ERROR:bibtexparser.bibdatabase:Circular crossref dependency: circ1->circ3->circ2->circ1.", cm.output)
         self.assertDictEqual(bibtex_database.entries_dict, entries_expected)
-        
+
     def test_crossref_missing_entries(self):
         input_file_path = 'bibtexparser/tests/data/crossref_missing_entries.bib'
         entries_expected = {'mcr': {'ENTRYTYPE': 'inbook',
@@ -217,8 +217,8 @@ class TestCrossRef(unittest.TestCase):
                                     'crossref': 'missing1',
                                     'origdate': '1933',
                                     'title': 'Lumbering Lunatics'}}
-        
-        parser = BibTexParser(add_missing_field_from_crossref=True)
+
+        parser = BibTexParser(add_missing_from_crossref=True)
         with self.assertLogs('bibtexparser.bibdatabase', level='ERROR') as cm:
             with open(input_file_path) as bibtex_file:
                 bibtex_database = parser.parse_file(bibtex_file)

--- a/bibtexparser/tests/test_crossref_resolving.py
+++ b/bibtexparser/tests/test_crossref_resolving.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from bibtexparser.bibdatabase import BibDatabase
 from bibtexparser.bparser import BibTexParser
 

--- a/bibtexparser/tests/test_crossref_resolving.py
+++ b/bibtexparser/tests/test_crossref_resolving.py
@@ -1,0 +1,229 @@
+import unittest
+from bibtexparser.bibdatabase import BibDatabase
+from bibtexparser.bparser import BibTexParser
+
+
+class TestCrossRef(unittest.TestCase):
+    def test_crossref(self):
+        self.maxDiff = None
+        input_file_path = 'bibtexparser/tests/data/crossref_entries.bib'
+        entries_expected = {'cr1': {'ENTRYTYPE': 'inbook',
+                                    'ID': 'cr1',
+                                    '_FROM_CROSSREF': ['editor', 'publisher', 'year'],
+                                    'archiveprefix': 'SomEPrFiX',
+                                    'author': 'Graham Gullam',
+                                    'crossref': 'cr_m',
+                                    'editor': 'Edgar Erbriss',
+                                    'origdate': '1955',
+                                    'primaryclass': 'SOMECLASS',
+                                    'publisher': 'Grimble',
+                                    'title': 'Great and Good Graphs',
+                                    'year': '1974'},
+                            'cr2': {'ENTRYTYPE': 'inbook',
+                                    'ID': 'cr2',
+                                    '_FROM_CROSSREF': ['editor', 'publisher', 'year'],
+                                    'author': 'Frederick Fumble',
+                                    'crossref': 'cr_m',
+                                    'editor': 'Edgar Erbriss',
+                                    'institution': 'Institution',
+                                    'origdate': '1943',
+                                    'publisher': 'Grimble',
+                                    'school': 'School',
+                                    'title': 'Fabulous Fourier Forms',
+                                    'year': '1974'},
+                            'cr3': {'ENTRYTYPE': 'inbook',
+                                    'ID': 'cr3',
+                                    '_FROM_CROSSREF': ['editor', 'publisher', 'year'],
+                                    'archiveprefix': 'SomEPrFiX',
+                                    'author': 'Arthur Aptitude',
+                                    'crossref': 'crt',
+                                    'editor': 'Mark Monkley',
+                                    'eprinttype': 'sometype',
+                                    'origdate': '1934',
+                                    'publisher': 'Rancour',
+                                    'title': 'Arrangements of All Articles',
+                                    'year': '1996'},
+                            'cr4': {'ENTRYTYPE': 'inbook',
+                                    'ID': 'cr4',
+                                    '_FROM_CROSSREF': ['editor', 'publisher', 'year'],
+                                    'author': 'Morris Mumble',
+                                    'crossref': 'crn',
+                                    'editor': 'Jeremy Jermain',
+                                    'origdate': '1911',
+                                    'publisher': 'Pillsbury',
+                                    'title': 'Enterprising Entities',
+                                    'year': '1945'},
+                            'cr5': {'ENTRYTYPE': 'inbook',
+                                    'ID': 'cr5',
+                                    '_FROM_CROSSREF': ['editor', 'publisher', 'year'],
+                                    'author': 'Oliver Ordinary',
+                                    'crossref': 'crn',
+                                    'editor': 'Jeremy Jermain',
+                                    'origdate': '1919',
+                                    'publisher': 'Pillsbury',
+                                    'title': 'Questionable Quidities',
+                                    'year': '1945'},
+                            'cr6': {'ENTRYTYPE': 'inproceedings',
+                                    'ID': 'cr6',
+                                    '_FROM_CROSSREF': ['address',
+                                                       'editor',
+                                                       'eventdate',
+                                                       'eventtitle',
+                                                       'publisher',
+                                                       'venue'],
+                                    'address': 'Address',
+                                    'author': 'Author, Firstname',
+                                    'booktitle': 'Manual booktitle',
+                                    'crossref': 'cr6i',
+                                    'editor': 'Editor',
+                                    'eventdate': '2009-08-21/2009-08-24',
+                                    'eventtitle': 'Title of the event',
+                                    'pages': '123--',
+                                    'publisher': 'Publisher of proceeding',
+                                    'title': 'Title of inproceeding',
+                                    'venue': 'Location of event',
+                                    'year': '2009'},
+                            'cr6i': {'ENTRYTYPE': 'proceedings',
+                                     'ID': 'cr6i',
+                                     'address': 'Address',
+                                     'author': 'Spurious Author',
+                                     'editor': 'Editor',
+                                     'eventdate': '2009-08-21/2009-08-24',
+                                     'eventtitle': 'Title of the event',
+                                     'publisher': 'Publisher of proceeding',
+                                     'title': 'Title of proceeding',
+                                     'venue': 'Location of event',
+                                     'year': '2009'},
+                            'cr7': {'ENTRYTYPE': 'inbook',
+                                    'ID': 'cr7',
+                                    '_FROM_CROSSREF': ['publisher', 'subtitle', 'titleaddon', 'verba'],
+                                    'author': 'Author, Firstname',
+                                    'crossref': 'cr7i',
+                                    'pages': '123--126',
+                                    'publisher': 'Publisher of proceeding',
+                                    'subtitle': 'Book Subtitle',
+                                    'title': 'Title of Book bit',
+                                    'titleaddon': 'Book Titleaddon',
+                                    'verba': 'String',
+                                    'year': '2010'},
+                            'cr7i': {'ENTRYTYPE': 'book',
+                                     'ID': 'cr7i',
+                                     'author': 'Brian Bookauthor',
+                                     'publisher': 'Publisher of proceeding',
+                                     'subtitle': 'Book Subtitle',
+                                     'title': 'Book Title',
+                                     'titleaddon': 'Book Titleaddon',
+                                     'verba': 'String',
+                                     'year': '2009'},
+                            'cr8': {'ENTRYTYPE': 'incollection',
+                                    'ID': 'cr8',
+                                    '_FROM_CROSSREF': ['editor', 'publisher', 'subtitle', 'titleaddon'],
+                                    'author': 'Smith, Firstname',
+                                    'crossref': 'cr8i',
+                                    'editor': 'Brian Editor',
+                                    'pages': '1--12',
+                                    'publisher': 'Publisher of Collection',
+                                    'subtitle': 'Book Subtitle',
+                                    'title': 'Title of Collection bit',
+                                    'titleaddon': 'Book Titleaddon',
+                                    'year': '2010'},
+                            'cr8i': {'ENTRYTYPE': 'collection',
+                                     'ID': 'cr8i',
+                                     'editor': 'Brian Editor',
+                                     'publisher': 'Publisher of Collection',
+                                     'subtitle': 'Book Subtitle',
+                                     'title': 'Book Title',
+                                     'titleaddon': 'Book Titleaddon',
+                                     'year': '2009'},
+                            'cr_m': {'ENTRYTYPE': 'book',
+                                     'ID': 'cr_m',
+                                     'editor': 'Edgar Erbriss',
+                                     'publisher': 'Grimble',
+                                     'title': 'Graphs of the Continent',
+                                     'year': '1974'},
+                            'crn': {'ENTRYTYPE': 'book',
+                                    'ID': 'crn',
+                                    'editor': 'Jeremy Jermain',
+                                    'publisher': 'Pillsbury',
+                                    'title': 'Vanquished, Victor, Vandal',
+                                    'year': '1945'},
+                            'crt': {'ENTRYTYPE': 'book',
+                                    'ID': 'crt',
+                                    'editor': 'Mark Monkley',
+                                    'publisher': 'Rancour',
+                                    'title': 'Beasts of the Burbling Burns',
+                                    'year': '1996'}}
+        parser = BibTexParser(add_missing_field_from_crossref=True, ignore_nonstandard_types=False)
+        with open(input_file_path) as bibtex_file:
+            bibtex_database = parser.parse_file(bibtex_file)
+        self.assertDictEqual(bibtex_database.entries_dict, entries_expected)
+
+    def test_crossref_cascading(self):
+        input_file_path = 'bibtexparser/tests/data/crossref_cascading.bib'
+        entries_expected = {'r1': {'ENTRYTYPE': 'book',
+                                   'ID': 'r1',
+                                   '_FROM_CROSSREF': [],
+                                   'crossref': 'r2',
+                                   'date': '1911'},
+                            'r2': {'ENTRYTYPE': 'book',
+                                   'ID': 'r2',
+                                   '_FROM_CROSSREF': [],
+                                   'crossref': 'r3',
+                                   'date': '1911'},
+                            'r3': {'ENTRYTYPE': 'book',
+                                   'ID': 'r3',
+                                   '_FROM_CROSSREF': [],
+                                   'crossref': 'r4',
+                                   'date': '1911'},
+                            'r4': {'ENTRYTYPE': 'book',
+                                   'ID': 'r4',
+                                   'date': '1911'}}
+        
+        parser = BibTexParser(add_missing_field_from_crossref=True)
+        with open(input_file_path) as bibtex_file:
+            bibtex_database = parser.parse_file(bibtex_file)
+        self.assertDictEqual(bibtex_database.entries_dict, entries_expected)
+        
+    def test_crossref_cascading_cycle(self):
+        input_file_path = 'bibtexparser/tests/data/crossref_cascading_cycle.bib'
+        entries_expected = {'circ1': {'ENTRYTYPE': 'book',
+                                      'ID': 'circ1',
+                                      '_FROM_CROSSREF': [],
+                                      'crossref': 'circ3',
+                                      'date': '1911'},
+                            'circ2': {'ENTRYTYPE': 'book',
+                                      'ID': 'circ2',
+                                      '_FROM_CROSSREF': [],
+                                      'crossref': 'circ1',
+                                      'date': '1911'},
+                            'circ3': {'ENTRYTYPE': 'book',
+                                      'ID': 'circ3',
+                                      '_FROM_CROSSREF': [],
+                                      'crossref': 'circ2',
+                                      'date': '1911'}}
+        parser = BibTexParser(add_missing_field_from_crossref=True)
+        with self.assertLogs('bibtexparser.bibdatabase', level='ERROR') as cm:
+            with open(input_file_path) as bibtex_file:
+                bibtex_database = parser.parse_file(bibtex_file)
+            self.assertIn("ERROR:bibtexparser.bibdatabase:Circular crossref dependance : circ1->circ3->circ2->circ1.", cm.output)
+        self.assertDictEqual(bibtex_database.entries_dict, entries_expected)
+        
+    def test_crossref_missing_entries(self):
+        input_file_path = 'bibtexparser/tests/data/crossref_missing_entries.bib'
+        entries_expected = {'mcr': {'ENTRYTYPE': 'inbook',
+                                    'ID': 'mcr',
+                                    '_crossref': 'missing1',
+                                    'author': 'Megan Mistrel',
+                                    'crossref': 'missing1',
+                                    'origdate': '1933',
+                                    'title': 'Lumbering Lunatics'}}
+        
+        parser = BibTexParser(add_missing_field_from_crossref=True)
+        with self.assertLogs('bibtexparser.bibdatabase', level='ERROR') as cm:
+            with open(input_file_path) as bibtex_file:
+                bibtex_database = parser.parse_file(bibtex_file)
+            self.assertIn("ERROR:bibtexparser.bibdatabase:Crossref reference missing1 for mcr is missing.", cm.output)
+        self.assertDictEqual(bibtex_database.entries_dict, entries_expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 future>=0.16.0
 pyparsing>=2.0.3
+unittest2>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,7 @@ setup(
     author_email = "devel@sciunto.org",
     description  = "Bibtex parser for python 2.7 and 3.3 and newer",
     packages     = ['bibtexparser'],
-    install_requires = ['pyparsing', 'future'],
+    install_requires = ['pyparsing>=2.0.3',
+                        'future>=0.16.0'],
+    extra_requires = {'unittest': 'unittest2>=1.1.0'}
 )


### PR DESCRIPTION
# crossref Support

bibtexparser does currently not resolve cross references. This pull request adds the support.

It is based on #109 by @flopraden, credit for the feature goes to him.

This pull request deprecates #109 and expands on it:
- Rebased onto master
- Commit message style fixed
- Failing unit tests fixed
- Clarified BibTeX assumptions
- Typos and minor fixes 

# References
* [BibLaTeX Documentation](http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf), Section 2.2.3 Special Fields (page 26)