### PR TITLE
Add very basic crossref documentation

### DIFF
--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -150,6 +150,8 @@ class BibDatabase(object):
         del entry['_crossref']
 
     def add_missing_from_crossref(self):
+        """Resolve crossrefs and update entries accordingly.
+        """
         self._crossref_updated = []
         for entry in self.entries:
             if "_crossref" in entry:

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -56,7 +56,7 @@ class BibTexParser(object):
     :param interpolate_strings: bool (default True)
         If True, replace bibtex string by their value, else uses
         BibDataString objects.
-    :param common_strings: book (default False)
+    :param common_strings: bool (default False)
         Include common string definitions (e.g. month abbreviations) to
         the bibtex file.
     :param add_missing_from_crossref: bool (default False)

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -59,6 +59,9 @@ class BibTexParser(object):
     :param common_strings: book (default False)
         Include common string definitions (e.g. month abbreviations) to
         the bibtex file.
+    :param add_missing_from_crossref: bool (default False)
+        Resolve BibTeX references set in the crossref field for BibTeX entries
+        and add the fields from the referenced entry to the referencing entry.
     """
 
     def __new__(cls, data=None, **args):


### PR DESCRIPTION
Previously missing from PR #216. 

Adds:
- Documentation for `add_missing_from_crossref` argument of `bparser`
- Documentation for public method `add_missing_from_crossref` for `BibDatabase`
