### PR TITLE
common strings where not present on parsing for months

### DIFF
--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -72,6 +72,7 @@ class BibDatabase(object):
 
         #: List of fields that should not be updated when resolving crossrefs
         self._not_updated_by_crossref = ['_FROM_CROSSREF']
+        self.load_common_strings()
 
     def load_common_strings(self):
         self.strings.update(COMMON_STRINGS)


### PR DESCRIPTION
I need this "hack" to have the months properly recognized.