### PR TITLE
Add ordering by ascending/descending to btexwriter

### DIFF
--- a/bibtexparser/tests/data/multiple_entries_sort.bib
+++ b/bibtexparser/tests/data/multiple_entries_sort.bib
@@ -1,0 +1,40 @@
+@Book{Yablon2005,
+    Title                    = {Optical fiber fusion slicing},
+    Author                   = {Yablon, A.D.},
+    Publisher                = {Springer},
+    Year                     = {2005},
+}
+
+@Article{Wigner1938,
+    Title                    = {The transition state method},
+    Author                   = {Wigner, E.},
+    Journal                  = {Trans. Faraday Soc.},
+    Year                     = {1938},
+    Pages                    = {29--41},
+    Volume                   = {34},
+    Doi                      = {10.1039/TF9383400029},
+    ISSN                     = {0014-7672},
+    Owner                    = {fr},
+    Publisher                = {The Royal Society of Chemistry},
+}
+
+@Book{nietzsche1996human,
+    Title                    = {Nietzsche: Human, all too human: A book for free spirits},
+    Author                   = {Nietzsche, Friedrich},
+    Year                     = {1996},
+    Publisher                = {Cambridge University Press},
+    Address                  = {Cambridge}
+}
+
+@Book{nietzsche2016anti,
+    Title                    = {Anti-Education: On the future of our educational institutions},
+    Author                   = {Nietzsche, Friedrich},
+    Year                     = {2016},
+    Publisher                = {New York Review of Books},
+    Address                  = {New York}
+}
+
+@Book{Toto3000,
+    Title                    = {A title},
+    Author                   = {Toto, A and Titi, B},
+}

--- a/bibtexparser/tests/data/multiple_entries_sort_output.bib
+++ b/bibtexparser/tests/data/multiple_entries_sort_output.bib
@@ -1,0 +1,41 @@
+@book{nietzsche2016anti,
+ address = {New York},
+ author = {Nietzsche, Friedrich},
+ publisher = {New York Review of Books},
+ title = {Anti-Education: On the future of our educational institutions},
+ year = {2016}
+}
+
+@book{nietzsche1996human,
+ address = {Cambridge},
+ author = {Nietzsche, Friedrich},
+ publisher = {Cambridge University Press},
+ title = {Nietzsche: Human, all too human: A book for free spirits},
+ year = {1996}
+}
+
+@book{Toto3000,
+ author = {Toto, A and Titi, B},
+ title = {A title}
+}
+
+@article{Wigner1938,
+ author = {Wigner, E.},
+ doi = {10.1039/TF9383400029},
+ issn = {0014-7672},
+ journal = {Trans. Faraday Soc.},
+ owner = {fr},
+ pages = {29--41},
+ publisher = {The Royal Society of Chemistry},
+ title = {The transition state method},
+ volume = {34},
+ year = {1938}
+}
+
+@book{Yablon2005,
+ author = {Yablon, A.D.},
+ publisher = {Springer},
+ title = {Optical fiber fusion slicing},
+ year = {2005}
+}
+

--- a/bibtexparser/tests/test_bwriter.py
+++ b/bibtexparser/tests/test_bwriter.py
@@ -115,3 +115,16 @@ class TestBibtexWriterList(unittest.TestCase):
         result = writer.write(bib)
         self.maxDiff = None
         self.assertEqual(expected, result)
+
+    def test_sort_reverse(self):
+        with io.open(_data_path('multiple_entries_sort.bib'), 'r') as bibfile:
+            bib = BibTexParser(bibfile.read())
+
+        with io.open(_data_path('multiple_entries_sort_output.bib'), 'r') as bibfile:
+            expected = bibfile.read()
+
+        writer = BibTexWriter()
+        writer.order_entries_by = ['author', '-year']
+        result = writer.write(bib)
+        self.maxDiff = None
+        self.assertEqual(expected, result)

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,6 @@
 envlist = py27,py35
 [testenv]
 deps = nose
+       unittest2
        pyparsing
 commands = nosetests


### PR DESCRIPTION
 Fixes #243: order by multiple keys in various directions

Also: add unittest2 to tox deps