### PR TITLE
Remove shebang lines from non-executable Python files

### DIFF
--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from collections import OrderedDict

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Original source: github.com/okfn/bibserver

--- a/bibtexparser/bwriter.py
+++ b/bibtexparser/bwriter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Author: Francois Boulogne
 # License:

--- a/bibtexparser/customization.py
+++ b/bibtexparser/customization.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/bibtexparser/latexenc.py
+++ b/bibtexparser/latexenc.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Original source: github.com/okfn/bibserver


### PR DESCRIPTION
I came across this while packaging python-bibtexparser for Fedora. See
https://bugzilla.redhat.com/show_bug.cgi?id=1812973

Signed-off-by: W. Michael Petullo <mike@flyn.org>