### PR TITLE
PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,21 @@ matrix:
       env: TEST_SUITE=suite_3_7
     - python: "pypy3.5-5.8.0"
       env: TEST_SUITE=suite_pypy3
+Exclude:
+  Jobs:
+    - python: "3.3"
+      env: TEST_SUITE=suite_3_3
+      arch: ppc64le
+    - python: "3.4"
+      env: TEST_SUITE=suite_3_4
+      arch: ppc64le
+    - python: "pypy3.5-5.8.0"
+      env: TEST_SUITE=suite_pypy3
+      arch: ppc64le
+
+      
+    
+    
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then
         pip install sphinx;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
       env: TEST_SUITE=suite_3_7
     - python: "pypy3.5-5.8.0"
       env: TEST_SUITE=suite_pypy3
-Exclude:
-  Jobs:
+  exclude:
+   Jobs:
     - python: "3.3"
       env: TEST_SUITE=suite_3_3
       arch: ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 language: python
+arch: ppc64le
 matrix:
   include:
     - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+arch: ppc64le
 dist: trusty
 language: python
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,30 @@ dist: trusty
 language: python
 matrix:
   include:
-     - python: "3.5"
+     - python: "3.3"
+      env: TEST_SUITE=suite_3_3
+    - python: "3.4"
+      env: TEST_SUITE=suite_3_4
+    - python: "3.5"
       env: TEST_SUITE=suite_3_5
-      arch: ppc64le
     - python: "3.6"
       env: TEST_SUITE=suite_3_6
-      arch: ppc64le
     - python: "3.7"
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
-      arch: ppc64le
-      
+    - python: "pypy3.5-5.8.0"
+      env: TEST_SUITE=suite_pypy3
+matrix: 
+  include:  
+    - python: "3.5"
+      env: TEST_SUITE=suite_3_5
+    - python: "3.6"
+      env: TEST_SUITE=suite_3_6
+    - python: "3.7"
+      dist: xenial # Required for Python 3.7
+      sudo: true   # travis-ci/travis-ci#9069
+      env: TEST_SUITE=suite_3_7
       
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,32 @@ matrix:
       arch: amd64
     - python: "3.5"
       env: TEST_SUITE=suite_3_5
+      arch: amd64
+    - python: "3.5"
+      env: TEST_SUITE=suite_3_5
       arch: ppc64le
+    - python: "3.6"
+      env: TEST_SUITE=suite_3_6
       arch: amd64
     - python: "3.6"
       env: TEST_SUITE=suite_3_6
-      arch: ppc64le
+      arch: ppc64le  
+    - python: "3.7"
+      dist: xenial # Required for Python 3.7
+      sudo: true   # travis-ci/travis-ci#9069
+      env: TEST_SUITE=suite_3_7
       arch: amd64
     - python: "3.7"
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
       arch: ppc64le
-      arch: amd64
     - python: "pypy3.5-5.8.0"
       env: TEST_SUITE=suite_pypy3
       arch: amd64
   
  
-    
+   
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then
         pip install sphinx;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
-arch: 
-    - ppc64le
-    - amd64
 dist: trusty
 language: python
 matrix:
   include:
+    - python: "3.3"
+      env: TEST_SUITE=suite_3_3
+    - python: "3.4"
+      env: TEST_SUITE=suite_3_4
     - python: "3.5"
       env: TEST_SUITE=suite_3_5
     - python: "3.6"
@@ -13,7 +14,8 @@ matrix:
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
-    
+    - python: "pypy3.5-5.8.0"
+      env: TEST_SUITE=suite_pypy3
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then
         pip install sphinx;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,15 @@ matrix:
   include:  
     - python: "3.5"
       env: TEST_SUITE=suite_3_5
+      arch: ppc64le
     - python: "3.6"
       env: TEST_SUITE=suite_3_6
+      arch: ppc64le
     - python: "3.7"
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
+      arch: ppc64le
       
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 dist: trusty
 language: python
-arch: ppc64le
-    
-    
-   
-   matrix:
+matrix:
   include:
     - python: "3.5"
       env: TEST_SUITE=suite_3_5
@@ -14,6 +10,7 @@ arch: ppc64le
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
+    
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then
         pip install sphinx;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,38 @@
-arch:
-    - ppc64le
-    - amd64
 dist: trusty
 language: python
 matrix:
   include:
     - python: "3.3"
       env: TEST_SUITE=suite_3_3
+      arch: amd64
     - python: "3.4"
       env: TEST_SUITE=suite_3_4
+      arch: amd64
     - python: "3.5"
       env: TEST_SUITE=suite_3_5
+      arch: ppc64le
+      arch: amd64
     - python: "3.6"
       env: TEST_SUITE=suite_3_6
+      arch: ppc64le
+      arch: amd64
     - python: "3.7"
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
+      arch: ppc64le
+      arch: amd64
     - python: "pypy3.5-5.8.0"
       env: TEST_SUITE=suite_pypy3
-  exclude:
-   Jobs:
-    - python: "3.3"
-      env: TEST_SUITE=suite_3_3
-      arch: ppc64le
-    - python: "3.4"
-      env: TEST_SUITE=suite_3_4
-      arch: ppc64le
-    - python: "pypy3.5-5.8.0"
-      env: TEST_SUITE=suite_pypy3
-      arch: ppc64le
-
-      
-    
+      arch: amd64
+  
+ 
     
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then
         pip install sphinx;
     fi;
-  - pip install coverage
-  - pip install -r requirements.txt
+  - pip install coverage - pip install -r requirements.txt
   - python setup.py install
 script:
   - nosetests --with-coverage  --cover-erase --cover-package=bibtexparser

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: trusty
 language: python
-arch: ppc64le
 matrix:
   include:
     - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,16 @@
 dist: trusty
 language: python
-matrix: 
-  include:  
+arch: ppc64le
+matrix:
+  include:
     - python: "3.5"
       env: TEST_SUITE=suite_3_5
-      arch: 
-       - ppc64le
-       -amd64
     - python: "3.6"
       env: TEST_SUITE=suite_3_6
-      arch: 
-       - ppc64le
-       -amd64
     - python: "3.7"
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
-      arch: 
-       - ppc64le
-       -amd64
-
-      
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then
         pip install sphinx;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,18 @@ matrix:
       env: TEST_SUITE=suite_3_7
     - python: "pypy3.5-5.8.0"
       env: TEST_SUITE=suite_pypy3
+      
+# Disable version 3.3, 3.2 & pypy
+jobs: 
+  exclude:
+    - arch: ppc64le
+      python: 3.3
+    - arch: ppc64le
+      python: 3.4
+    - arch: ppc64le
+      python: pypy3.5-5.8.0
+  
+      
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then
         pip install sphinx;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: trusty
 language: python
-arch: 
-  - ppc64le
-  - amd64
+  arch: 
+    - ppc64le
+    - amd64
 matrix:
   include:
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
-arch: 
-     - ppc64le
-
 dist: trusty
 language: python
 matrix:
   include:
      - python: "3.5"
       env: TEST_SUITE=suite_3_5
+      arch: ppc64le
     - python: "3.6"
       env: TEST_SUITE=suite_3_6
+      arch: ppc64le
     - python: "3.7"
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
+      arch: ppc64le
       
       
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 arch: 
-    - amd64
-    - ppc64le
+     - ppc64le
 
 dist: trusty
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,13 @@ matrix:
       arch: amd64
   
  
-   
+
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then
         pip install sphinx;
     fi;
-  - pip install coverage - pip install -r requirements.txt
+  - pip install coverage 
+  - pip install -r requirements.txt
   - python setup.py install
 script:
   - nosetests --with-coverage  --cover-erase --cover-package=bibtexparser

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 dist: trusty
 language: python
-  arch: 
-    - ppc64le
-    - amd64
+arch: - ppc64le
+      - amd64
 matrix:
   include:
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,25 @@
 dist: trusty
 language: python
-matrix:
-  include:
-     - python: "3.3"
-      env: TEST_SUITE=suite_3_3
-    - python: "3.4"
-      env: TEST_SUITE=suite_3_4
-    - python: "3.5"
-      env: TEST_SUITE=suite_3_5
-    - python: "3.6"
-      env: TEST_SUITE=suite_3_6
-    - python: "3.7"
-      dist: xenial # Required for Python 3.7
-      sudo: true   # travis-ci/travis-ci#9069
-      env: TEST_SUITE=suite_3_7
-    - python: "pypy3.5-5.8.0"
-      env: TEST_SUITE=suite_pypy3
 matrix: 
   include:  
     - python: "3.5"
       env: TEST_SUITE=suite_3_5
-      arch: ppc64le
+      arch: 
+       - ppc64le
+       -amd64
     - python: "3.6"
       env: TEST_SUITE=suite_3_6
-      arch: ppc64le
+      arch: 
+       - ppc64le
+       -amd64
     - python: "3.7"
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
-      arch: ppc64le
+      arch: 
+       - ppc64le
+       -amd64
+
       
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+    - ppc64le
+    - amd64
 dist: trusty
 language: python
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch: 
+    - ppc64le
+    - amd64
 dist: trusty
 language: python
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: trusty
 language: python
-arch: ppc64le
+arch: 
+  - ppc64le
+  - amd64
 matrix:
   include:
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
-arch: ppc64le
+arch: 
+    - ppc64le
+    - amd64
+
 dist: trusty
 language: python
 matrix:
   include:
-    - python: "3.3"
-      env: TEST_SUITE=suite_3_3
-    - python: "3.4"
-      env: TEST_SUITE=suite_3_4
-    - python: "3.5"
+     - python: "3.5"
       env: TEST_SUITE=suite_3_5
     - python: "3.6"
       env: TEST_SUITE=suite_3_6
@@ -15,19 +14,7 @@ matrix:
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: TEST_SUITE=suite_3_7
-    - python: "pypy3.5-5.8.0"
-      env: TEST_SUITE=suite_pypy3
       
-# Disable version 3.3, 3.2 & pypy
-jobs: 
-  exclude:
-    - arch: ppc64le
-      python: 3.3
-    - arch: ppc64le
-      python: 3.4
-    - arch: ppc64le
-      python: pypy3.5-5.8.0
-  
       
 install:
   - if [[ $TEST_SUITE == suite_3_6 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 dist: trusty
 language: python
-arch: - ppc64le
-      - amd64
+arch: 
+    - ppc64le
+    - amd64
+    
 matrix:
   include:
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 arch: 
-    - ppc64le
     - amd64
+    - ppc64le
 
 dist: trusty
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: trusty
 language: python
-arch: 
-    - ppc64le
-    - amd64
+arch: ppc64le
     
-matrix:
+    
+   
+   matrix:
   include:
     - python: "3.5"
       env: TEST_SUITE=suite_3_5


### PR DESCRIPTION
Adding power support ppc64le
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
The Python 3.3/3.4/pypy3.5-5.8.0 are not available for download and hence build for these versions is giving error, however Python 3.5/3.6/3.7 are working fine.

The build is successful for both arch: amd64 & ppc64le 
