### PR TITLE
Allow preservation of existing order of entry fields in writer

### DIFF
--- a/bibtexparser/bwriter.py
+++ b/bibtexparser/bwriter.py
@@ -114,6 +114,8 @@ class BibTexWriter(object):
         return bibtex
 
     def _entry_to_bibtex(self, entry):
+        from itertools import chain
+
         bibtex = ''
         # Write BibTeX key
         bibtex += '@' + entry['ENTRYTYPE'] + '{' + entry['ID']
@@ -121,9 +123,10 @@ class BibTexWriter(object):
         if self.display_order is not None:
             # create display_order of fields for this entry
             # first those keys which are both in self.display_order and in entry.keys
-            display_order = [i for i in self.display_order if i in entry]
             # then all the other fields sorted alphabetically
-            display_order += [i for i in sorted(entry) if i not in self.display_order]
+            display_order = chain(
+                i for i in self.display_order if i in entry,
+                i for i in sorted(entry) if i not in self.display_order)
         else:
             # use pre-existing order
             display_order = reversed(entry)
@@ -131,9 +134,9 @@ class BibTexWriter(object):
             field_fmt = u"\n{indent}, {field:<{field_max_w}} = {value}"
         else:
             field_fmt = u",\n{indent}{field:<{field_max_w}} = {value}"
-        
+
         # Write "field = value' lines
-        for field in [i for i in display_order if i not in ['ENTRYTYPE', 'ID']]:
+        for field in (i for i in display_order if i not in ['ENTRYTYPE', 'ID']):
             try:
                 bibtex += field_fmt.format(
                     indent=self.indent,

--- a/bibtexparser/bwriter.py
+++ b/bibtexparser/bwriter.py
@@ -118,16 +118,21 @@ class BibTexWriter(object):
         # Write BibTeX key
         bibtex += '@' + entry['ENTRYTYPE'] + '{' + entry['ID']
 
-        # create display_order of fields for this entry
-        # first those keys which are both in self.display_order and in entry.keys
-        display_order = [i for i in self.display_order if i in entry]
-        # then all the other fields sorted alphabetically
-        display_order += [i for i in sorted(entry) if i not in self.display_order]
+        if self.display_order is not None:
+            # create display_order of fields for this entry
+            # first those keys which are both in self.display_order and in entry.keys
+            display_order = [i for i in self.display_order if i in entry]
+            # then all the other fields sorted alphabetically
+            display_order += [i for i in sorted(entry) if i not in self.display_order]
+        else:
+            # use pre-existing order
+            display_order = reversed(entry)
         if self.comma_first:
             field_fmt = u"\n{indent}, {field:<{field_max_w}} = {value}"
         else:
             field_fmt = u",\n{indent}{field:<{field_max_w}} = {value}"
-        # Write field = value lines
+        
+        # Write "field = value' lines
         for field in [i for i in display_order if i not in ['ENTRYTYPE', 'ID']]:
             try:
                 bibtex += field_fmt.format(
@@ -144,6 +149,7 @@ class BibTexWriter(object):
             else:
                 bibtex += ','
         bibtex += "\n}\n" + self.entry_separator
+        
         return bibtex
 
     def _comments_to_bibtex(self, bib_database):

--- a/bibtexparser/tests/test_bibtexwriter.py
+++ b/bibtexparser/tests/test_bibtexwriter.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import tempfile
+from textwrap import dedent
 import unittest
 import bibtexparser
 from bibtexparser.bwriter import BibTexWriter
@@ -13,33 +14,33 @@ class TestBibTexWriter(unittest.TestCase):
         writer = BibTexWriter()
         writer.contents = ['entries']
         result = bibtexparser.dumps(bib_database, writer)
-        expected = \
-"""@book{Toto3000,
- author = {Toto, A and Titi, B},
- title = {A title}
-}
+        expected = dedent("""\
+            @book{Toto3000,
+             author = {Toto, A and Titi, B},
+             title = {A title}
+            }
 
-@article{Wigner1938,
- author = {Wigner, E.},
- doi = {10.1039/TF9383400029},
- issn = {0014-7672},
- journal = {Trans. Faraday Soc.},
- owner = {fr},
- pages = {29--41},
- publisher = {The Royal Society of Chemistry},
- title = {The transition state method},
- volume = {34},
- year = {1938}
-}
+            @article{Wigner1938,
+             author = {Wigner, E.},
+             doi = {10.1039/TF9383400029},
+             issn = {0014-7672},
+             journal = {Trans. Faraday Soc.},
+             owner = {fr},
+             pages = {29--41},
+             publisher = {The Royal Society of Chemistry},
+             title = {The transition state method},
+             volume = {34},
+             year = {1938}
+            }
 
-@book{Yablon2005,
- author = {Yablon, A.D.},
- publisher = {Springer},
- title = {Optical fiber fusion slicing},
- year = {2005}
-}
+            @book{Yablon2005,
+             author = {Yablon, A.D.},
+             publisher = {Springer},
+             title = {Optical fiber fusion slicing},
+             year = {2005}
+            }
 
-"""
+            """)
         self.assertEqual(result, expected)
 
     def test_content_comment_only(self):
@@ -48,12 +49,12 @@ class TestBibTexWriter(unittest.TestCase):
         writer = BibTexWriter()
         writer.contents = ['comments']
         result = bibtexparser.dumps(bib_database, writer)
-        expected = \
-"""@comment{}
+        expected = dedent("""\
+            @comment{}
 
-@comment{A comment}
+            @comment{A comment}
 
-"""
+            """)
         self.assertEqual(result, expected)
 
     def test_indent(self):
@@ -62,14 +63,14 @@ class TestBibTexWriter(unittest.TestCase):
                                  'ENTRYTYPE': 'book',
                                  'author': 'test'}]
         writer = BibTexWriter()
-        writer.indent = '  '
+        writer.indent = '    '
         result = bibtexparser.dumps(bib_database, writer)
-        expected = \
-"""@book{abc123,
-  author = {test}
-}
+        expected = dedent("""\
+            @book{abc123,
+                author = {test}
+            }
 
-"""
+            """)
         self.assertEqual(result, expected)
 
     def test_align(self):
@@ -81,13 +82,13 @@ class TestBibTexWriter(unittest.TestCase):
         writer = BibTexWriter()
         writer.align_values = True
         result = bibtexparser.dumps(bib_database, writer)
-        expected = \
-"""@book{abc123,
- author             = {test},
- thisisaverylongkey = {longvalue}
-}
+        expected = dedent("""\
+            @book{abc123,
+             author             = {test},
+             thisisaverylongkey = {longvalue}
+            }
 
-"""
+            """)
         self.assertEqual(result, expected)
 
         with open('bibtexparser/tests/data/multiple_entries_and_comments.bib') as bibtex_file:
@@ -96,33 +97,33 @@ class TestBibTexWriter(unittest.TestCase):
         writer.contents = ['entries']
         writer.align_values = True
         result = bibtexparser.dumps(bib_database, writer)
-        expected = \
-"""@book{Toto3000,
- author    = {Toto, A and Titi, B},
- title     = {A title}
-}
+        expected = dedent("""\
+            @book{Toto3000,
+             author    = {Toto, A and Titi, B},
+             title     = {A title}
+            }
 
-@article{Wigner1938,
- author    = {Wigner, E.},
- doi       = {10.1039/TF9383400029},
- issn      = {0014-7672},
- journal   = {Trans. Faraday Soc.},
- owner     = {fr},
- pages     = {29--41},
- publisher = {The Royal Society of Chemistry},
- title     = {The transition state method},
- volume    = {34},
- year      = {1938}
-}
+            @article{Wigner1938,
+             author    = {Wigner, E.},
+             doi       = {10.1039/TF9383400029},
+             issn      = {0014-7672},
+             journal   = {Trans. Faraday Soc.},
+             owner     = {fr},
+             pages     = {29--41},
+             publisher = {The Royal Society of Chemistry},
+             title     = {The transition state method},
+             volume    = {34},
+             year      = {1938}
+            }
 
-@book{Yablon2005,
- author    = {Yablon, A.D.},
- publisher = {Springer},
- title     = {Optical fiber fusion slicing},
- year      = {2005}
-}
+            @book{Yablon2005,
+             author    = {Yablon, A.D.},
+             publisher = {Springer},
+             title     = {Optical fiber fusion slicing},
+             year      = {2005}
+            }
 
-"""
+            """)
         self.assertEqual(result, expected)
 
 
@@ -134,11 +135,11 @@ class TestBibTexWriter(unittest.TestCase):
         writer = BibTexWriter()
         writer.entry_separator = ''
         result = bibtexparser.dumps(bib_database, writer)
-        expected = \
-"""@book{abc123,
- author = {test}
-}
-"""
+        expected = dedent("""\
+            @book{abc123,
+             author = {test}
+            }
+            """)
         self.assertEqual(result, expected)
 
     def test_display_order(self):
@@ -148,33 +149,33 @@ class TestBibTexWriter(unittest.TestCase):
         writer.contents = ['entries']
         writer.display_order = ['year', 'publisher', 'title']
         result = bibtexparser.dumps(bib_database, writer)
-        expected = \
-"""@book{Toto3000,
- title = {A title},
- author = {Toto, A and Titi, B}
-}
+        expected = dedent("""\
+            @book{Toto3000,
+             title = {A title},
+             author = {Toto, A and Titi, B}
+            }
 
-@article{Wigner1938,
- year = {1938},
- publisher = {The Royal Society of Chemistry},
- title = {The transition state method},
- author = {Wigner, E.},
- doi = {10.1039/TF9383400029},
- issn = {0014-7672},
- journal = {Trans. Faraday Soc.},
- owner = {fr},
- pages = {29--41},
- volume = {34}
-}
+            @article{Wigner1938,
+             year = {1938},
+             publisher = {The Royal Society of Chemistry},
+             title = {The transition state method},
+             author = {Wigner, E.},
+             doi = {10.1039/TF9383400029},
+             issn = {0014-7672},
+             journal = {Trans. Faraday Soc.},
+             owner = {fr},
+             pages = {29--41},
+             volume = {34}
+            }
 
-@book{Yablon2005,
- year = {2005},
- publisher = {Springer},
- title = {Optical fiber fusion slicing},
- author = {Yablon, A.D.}
-}
+            @book{Yablon2005,
+             year = {2005},
+             publisher = {Springer},
+             title = {Optical fiber fusion slicing},
+             author = {Yablon, A.D.}
+            }
 
-"""
+            """)
         self.assertEqual(result, expected)
 
 
@@ -238,24 +239,24 @@ class TestEntrySorting(unittest.TestCase):
 
     def test_unicode_problems(self):
         # See #51
-        bibtex = """
-        @article{Mesa-Gresa2013,
-            abstract = {During a 4-week period half the mice (n = 16) were exposed to EE and the other half (n = 16) remained in a standard environment (SE). Aggr. Behav. 9999:XX-XX, 2013. © 2013 Wiley Periodicals, Inc.},
-            author = {Mesa-Gresa, Patricia and P\'{e}rez-Martinez, Asunci\'{o}n and Redolat, Rosa},
-            doi = {10.1002/ab.21481},
-            file = {:Users/jscholz/Documents/mendeley/Mesa-Gresa, P\'{e}rez-Martinez, Redolat - 2013 - Environmental Enrichment Improves Novel Object Recognition and Enhances Agonistic Behavior.pdf:pdf},
-            issn = {1098-2337},
-            journal = {Aggressive behavior},
-            month = "apr",
-            number = {April},
-            pages = {269--279},
-            pmid = {23588702},
-            title = {{Environmental Enrichment Improves Novel Object Recognition and Enhances Agonistic Behavior in Male Mice.}},
-            url = {http://www.ncbi.nlm.nih.gov/pubmed/23588702},
-            volume = {39},
-            year = {2013}
-        }
-        """
+        bibtex = """\
+            @article{Mesa-Gresa2013,
+                abstract = {During a 4-week period half the mice (n = 16) were exposed to EE and the other half (n = 16) remained in a standard environment (SE). Aggr. Behav. 9999:XX-XX, 2013. © 2013 Wiley Periodicals, Inc.},
+                author = {Mesa-Gresa, Patricia and P\'{e}rez-Martinez, Asunci\'{o}n and Redolat, Rosa},
+                doi = {10.1002/ab.21481},
+                file = {:Users/jscholz/Documents/mendeley/Mesa-Gresa, P\'{e}rez-Martinez, Redolat - 2013 - Environmental Enrichment Improves Novel Object Recognition and Enhances Agonistic Behavior.pdf:pdf},
+                issn = {1098-2337},
+                journal = {Aggressive behavior},
+                month = "apr",
+                number = {April},
+                pages = {269--279},
+                pmid = {23588702},
+                title = {{Environmental Enrichment Improves Novel Object Recognition and Enhances Agonistic Behavior in Male Mice.}},
+                url = {http://www.ncbi.nlm.nih.gov/pubmed/23588702},
+                volume = {39},
+                year = {2013}
+            }
+            """
         bibdb = bibtexparser.loads(bibtex)
         with tempfile.TemporaryFile(mode='w+') as bibtex_file:
             bibtexparser.dump(bibdb, bibtex_file)

--- a/bibtexparser/tests/test_bibtexwriter.py
+++ b/bibtexparser/tests/test_bibtexwriter.py
@@ -177,6 +177,42 @@ class TestBibTexWriter(unittest.TestCase):
 
             """)
         self.assertEqual(result, expected)
+    
+    def test_display_order_none(self):
+        with open('bibtexparser/tests/data/multiple_entries_and_comments.bib') as bibtex_file:
+            bib_database = bibtexparser.load(bibtex_file)
+        writer = BibTexWriter()
+        writer.contents = ['entries']
+        writer.display_order = None
+        result = bibtexparser.dumps(bib_database, writer)
+        expected = dedent("""\
+            @book{Toto3000,
+             title = {A title},
+             author = {Toto, A and Titi, B}
+            }
+
+            @article{Wigner1938,
+             title = {The transition state method},
+             author = {Wigner, E.},
+             journal = {Trans. Faraday Soc.},
+             year = {1938},
+             pages = {29--41},
+             volume = {34},
+             doi = {10.1039/TF9383400029},
+             issn = {0014-7672},
+             owner = {fr},
+             publisher = {The Royal Society of Chemistry}
+            }
+
+            @book{Yablon2005,
+             title = {Optical fiber fusion slicing},
+             author = {Yablon, A.D.},
+             publisher = {Springer},
+             year = {2005}
+            }
+
+            """)
+        self.assertEqual(result, expected)
 
 
 class TestEntrySorting(unittest.TestCase):


### PR DESCRIPTION
This should be fairly self-explanatory. I couldn't immediately see why `display_order = reversed(entry)` is correct to preserve the pre-existing order of fields, but it seems to work reliably.