### PR TITLE
Load common strings if none is provided- fix #280

### DIFF
--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -87,7 +87,7 @@ class BibTexParser(object):
         #: Load common strings such as months abbreviation
         #: Default: `False`.
         self.common_strings = common_strings
-        if self.common_strings:
+        if not self.common_strings:
             self.bib_database.load_common_strings()
 
         #: Callback function to process BibTeX entries after parsing,


### PR DESCRIPTION
```py
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/bibtexparser/bibdatabase.py", line 107, in expand_string
    self.strings[name])
KeyError: 'jan'
```

The common strings are loaded if the common string definition is included, but shouldn't it be the opposite? Load the common strings if none is provided.

This change (PR) did the work. 