### PR TITLE
Author split case-insensitive

### DIFF
--- a/bibtexparser/customization.py
+++ b/bibtexparser/customization.py
@@ -345,7 +345,7 @@ def author(record):
     """
     if "author" in record:
         if record["author"]:
-            record["author"] = getnames([i.strip() for i in record["author"].replace('\n', ' ').split(" and ")])
+            record["author"] = getnames([i.strip() for i in re.split(r"\ and\ ", record["author"].replace('\n', ' '), flags=re.IGNORECASE)])
         else:
             del record["author"]
     return record


### PR DESCRIPTION
I have recently parsed a BibTeX library of a colleague who used `AND` to separate authors on some occasions