### PR TITLE
✨ Add option to adjust alignment of text of multi-line values.

### DIFF
--- a/bibtexparser/bwriter.py
+++ b/bibtexparser/bwriter.py
@@ -58,6 +58,8 @@ class BibTexWriter(object):
         #: Align values. Determines the maximal number of characters used in any fieldname and aligns all values
         #    according to that by filling up with single spaces. Default: False
         self.align_values = False
+        # Align multi-line values. Formats a multi-line value such that the text is aligned exactly on top of each other.
+        self.align_multiline_values = False
         #: Characters(s) for separating BibTeX entries. Default: new line.
         self.entry_separator = '\n'
         #: Tuple of fields for ordering BibTeX entries. Set to `None` to disable sorting. Default: BibTeX key `('ID', )`.
@@ -127,11 +129,31 @@ class BibTexWriter(object):
         # Write field = value lines
         for field in [i for i in display_order if i not in ['ENTRYTYPE', 'ID']]:
             try:
+                value = _str_or_expr_to_bibtex(entry[field])
+
+                if self.align_multiline_values:
+                    # Calculate indent of multi-line values. Text from a multiline string
+                    # should be aligned, i.e., be exactly on top of each other.
+                    # E.g.:       title = {Hello
+                    #                      World}
+                    # Calculate the indent of "World":
+                    # Left of field (whitespaces before e.g. 'title')
+                    value_indent = len(self.indent)
+                    # Field itself (e.g. len('title'))
+                    if self._max_field_width > 0:
+                        value_indent += self._max_field_width
+                    else:
+                        value_indent += len(field)
+                    # Right of field ' = ' (<- 3 chars) + '{' (<- 1 char)
+                    value_indent += 3 + 1
+
+                    value = value.replace('\n', '\n' + value_indent * ' ')
+
                 bibtex += field_fmt.format(
                     indent=self.indent,
                     field=field,
                     field_max_w=self._max_field_width,
-                    value=_str_or_expr_to_bibtex(entry[field]))
+                    value=value)
             except TypeError:
                 raise TypeError(u"The field %s in entry %s must be a string"
                                 % (field, entry['ID']))

--- a/bibtexparser/bwriter.py
+++ b/bibtexparser/bwriter.py
@@ -58,7 +58,8 @@ class BibTexWriter(object):
         #: Align values. Determines the maximal number of characters used in any fieldname and aligns all values
         #    according to that by filling up with single spaces. Default: False
         self.align_values = False
-        # Align multi-line values. Formats a multi-line value such that the text is aligned exactly on top of each other.
+        #: Align multi-line values. Formats a multi-line value such that the text is aligned exactly
+        #    on top of each other. Default: False
         self.align_multiline_values = False
         #: Characters(s) for separating BibTeX entries. Default: new line.
         self.entry_separator = '\n'

--- a/bibtexparser/tests/data/article_multilines.bib
+++ b/bibtexparser/tests/data/article_multilines.bib
@@ -1,0 +1,13 @@
+@ARTICLE{Cesar2013,
+  author = {Jean César},
+  title = {A mutline line title is very amazing. It should be
+long enough to test multilines... with two lines or should we
+even test three lines... What an amazing title.},
+  year = {2013},
+  journal = {Nice Journal},
+  abstract = {This is an abstract. This line should be long enough to test
+multilines... and with a french érudit word},
+  comments = {A comment},
+  keyword = {keyword1, keyword2,
+multiline-keyword1, multiline-keyword2},
+}

--- a/bibtexparser/tests/test_bibtexwriter.py
+++ b/bibtexparser/tests/test_bibtexwriter.py
@@ -172,7 +172,7 @@ class TestBibTexWriter(unittest.TestCase):
 """
         self.assertEqual(result, expected)
 
-    def test_align_mutliline_values(self):
+    def test_align_multiline_values(self):
         with open('bibtexparser/tests/data/article_multilines.bib') as bibtex_file:
             bib_database = bibtexparser.load(bibtex_file)
         writer = BibTexWriter()
@@ -192,6 +192,82 @@ class TestBibTexWriter(unittest.TestCase):
  comments = {A comment},
  keyword = {keyword1, keyword2,
             multiline-keyword1, multiline-keyword2}
+}
+"""
+        self.assertEqual(result, expected)
+
+    def test_align_multiline_values_with_align(self):
+        with open('bibtexparser/tests/data/article_multilines.bib') as bibtex_file:
+            bib_database = bibtexparser.load(bibtex_file)
+        writer = BibTexWriter()
+        writer.align_multiline_values = True
+        writer.align_values = True
+        writer.display_order = ["author", "title", "year", "journal", "abstract", "comments", "keyword"]
+        result = bibtexparser.dumps(bib_database, writer)
+        expected = \
+"""@article{Cesar2013,
+ author    = {Jean César},
+ title     = {A mutline line title is very amazing. It should be
+              long enough to test multilines... with two lines or should we
+              even test three lines... What an amazing title.},
+ year      = {2013},
+ journal   = {Nice Journal},
+ abstract  = {This is an abstract. This line should be long enough to test
+              multilines... and with a french érudit word},
+ comments  = {A comment},
+ keyword   = {keyword1, keyword2,
+              multiline-keyword1, multiline-keyword2}
+}
+"""
+        self.assertEqual(result, expected)
+
+    def test_align_multiline_values_with_indent(self):
+        with open('bibtexparser/tests/data/article_multilines.bib') as bibtex_file:
+            bib_database = bibtexparser.load(bibtex_file)
+        writer = BibTexWriter()
+        writer.align_multiline_values = True
+        writer.indent = ' ' * 3
+        writer.display_order = ["author", "title", "year", "journal", "abstract", "comments", "keyword"]
+        result = bibtexparser.dumps(bib_database, writer)
+        expected = \
+"""@article{Cesar2013,
+   author = {Jean César},
+   title = {A mutline line title is very amazing. It should be
+            long enough to test multilines... with two lines or should we
+            even test three lines... What an amazing title.},
+   year = {2013},
+   journal = {Nice Journal},
+   abstract = {This is an abstract. This line should be long enough to test
+               multilines... and with a french érudit word},
+   comments = {A comment},
+   keyword = {keyword1, keyword2,
+              multiline-keyword1, multiline-keyword2}
+}
+"""
+        self.assertEqual(result, expected)
+
+    def test_align_multiline_values_with_align_with_indent(self):
+        with open('bibtexparser/tests/data/article_multilines.bib') as bibtex_file:
+            bib_database = bibtexparser.load(bibtex_file)
+        writer = BibTexWriter()
+        writer.align_multiline_values = True
+        writer.indent = ' ' * 3
+        writer.align_values = True
+        writer.display_order = ["author", "title", "year", "journal", "abstract", "comments", "keyword"]
+        result = bibtexparser.dumps(bib_database, writer)
+        expected = \
+"""@article{Cesar2013,
+   author    = {Jean César},
+   title     = {A mutline line title is very amazing. It should be
+                long enough to test multilines... with two lines or should we
+                even test three lines... What an amazing title.},
+   year      = {2013},
+   journal   = {Nice Journal},
+   abstract  = {This is an abstract. This line should be long enough to test
+                multilines... and with a french érudit word},
+   comments  = {A comment},
+   keyword   = {keyword1, keyword2,
+                multiline-keyword1, multiline-keyword2}
 }
 """
         self.assertEqual(result, expected)

--- a/bibtexparser/tests/test_bibtexwriter.py
+++ b/bibtexparser/tests/test_bibtexwriter.py
@@ -172,6 +172,30 @@ class TestBibTexWriter(unittest.TestCase):
 """
         self.assertEqual(result, expected)
 
+    def test_align_mutliline_values(self):
+        with open('bibtexparser/tests/data/article_multilines.bib') as bibtex_file:
+            bib_database = bibtexparser.load(bibtex_file)
+        writer = BibTexWriter()
+        writer.align_multiline_values = True
+        writer.display_order = ["author", "title", "year", "journal", "abstract", "comments", "keyword"]
+        result = bibtexparser.dumps(bib_database, writer)
+        expected = \
+"""@article{Cesar2013,
+ author = {Jean César},
+ title = {A mutline line title is very amazing. It should be
+          long enough to test multilines... with two lines or should we
+          even test three lines... What an amazing title.},
+ year = {2013},
+ journal = {Nice Journal},
+ abstract = {This is an abstract. This line should be long enough to test
+             multilines... and with a french érudit word},
+ comments = {A comment},
+ keyword = {keyword1, keyword2,
+            multiline-keyword1, multiline-keyword2}
+}
+"""
+        self.assertEqual(result, expected)
+
 
 class TestEntrySorting(unittest.TestCase):
     bib_database = BibDatabase()


### PR DESCRIPTION
A new option `align_multiline_values` is added to BibTexWriter to enable whether text of multiline values should be aligned on top of each other. Indentation also considered `_max_field_width`.

Current behaviour:
BibTeX entry:
```
@article{test,
  title     = {Hello World. I'm a very very very
  very very very very long title. Hello Bibtex Parser!
  This is still a long title!},
}
```

Parsing with BibtexParser will result in:
```
@article{test,
 title = {Hello World. I'm a very very very
very very very very long title. Hello Bibtex Parser!
This is still a long title!}
}
```

When `align_multiline_values` is set to true, the output will be the
following:
```
@article{test,
 title = {Hello World. I'm a very very very
          very very very very long title. Hello Bibtex Parser!
          This is still a long title!}
}
```