### PR TITLE
Update bibdatabase.py

### DIFF
--- a/bibtexparser/bibdatabase.py
+++ b/bibtexparser/bibdatabase.py
@@ -65,6 +65,9 @@ class BibDatabase(object):
 
         #: List of fields that should not be updated when resolving crossrefs
         self._not_updated_by_crossref = ['_FROM_CROSSREF']
+        
+        #: Aliases of common strings
+        self.load_common_strings()
 
     def load_common_strings(self):
         self.strings.update(COMMON_STRINGS)


### PR DESCRIPTION
Make use of the COMMON_STRINGS variable

COMMON_STRINGS currently contains string aliases of month names. Before this change, the parser fails when it encounters these aliases for the "month" field of a bibtex item.