### PR TITLE
:white_check_mark: Fix file encoding in tests

### DIFF
--- a/bibtexparser/tests/test_bibtexparser.py
+++ b/bibtexparser/tests/test_bibtexparser.py
@@ -32,7 +32,7 @@ class TestBibtexParserParserMethods(unittest.TestCase):
 
     def test_parse_bom_str(self):
         parser = BibTexParser()
-        with open(self.input_bom_file_path) as bibtex_file:
+        with open(self.input_bom_file_path, encoding="utf-8") as bibtex_file:
             bibtex_str = bibtex_file.read()
             bibtex_database = parser.parse(bibtex_str)
         self.assertEqual(bibtex_database.entries, self.entries_expected)

--- a/bibtexparser/tests/test_bibtexwriter.py
+++ b/bibtexparser/tests/test_bibtexwriter.py
@@ -252,7 +252,7 @@ class TestEntrySorting(unittest.TestCase):
         }
         """
         bibdb = bibtexparser.loads(bibtex)
-        with tempfile.TemporaryFile(mode='w+') as bibtex_file:
+        with tempfile.TemporaryFile(mode='w+', encoding="utf-8") as bibtex_file:
             bibtexparser.dump(bibdb, bibtex_file)
             # No exception should be raised
 

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -320,7 +320,8 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_article_no_braces(self):
-        with open('bibtexparser/tests/data/article_no_braces.bib', 'r') as bibfile:
+        with open('bibtexparser/tests/data/article_no_braces.bib', 'r',
+                  encoding="utf-8") as bibfile:
             bib = BibTexParser(bibfile.read())
             res = bib.get_entry_list()
         expected = [{'ENTRYTYPE': 'article',
@@ -340,7 +341,8 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_article_special_characters(self):
-        with open('bibtexparser/tests/data/article_with_special_characters.bib', 'r') as bibfile:
+        with open('bibtexparser/tests/data/article_with_special_characters.bib', 'r',
+                  encoding="utf-8") as bibfile:
             bib = BibTexParser(bibfile.read())
             res = bib.get_entry_list()
         expected = [{'ENTRYTYPE': 'article',
@@ -360,7 +362,8 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_article_protection_braces(self):
-        with open('bibtexparser/tests/data/article_with_protection_braces.bib', 'r') as bibfile:
+        with open('bibtexparser/tests/data/article_with_protection_braces.bib', 'r',
+                  encoding="utf-8") as bibfile:
             bib = BibTexParser(bibfile.read())
             res = bib.get_entry_list()
         expected = [{'ENTRYTYPE': 'article',
@@ -532,7 +535,8 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_field_name_with_dash_underscore(self):
-        with open('bibtexparser/tests/data/article_field_name_with_underscore.bib', 'r') as bibfile:
+        with open('bibtexparser/tests/data/article_field_name_with_underscore.bib', 'r',
+                  encoding="utf-8") as bibfile:
             bib = BibTexParser(bibfile.read())
         res = bib.get_entry_list()
         expected = [{
@@ -552,7 +556,8 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_string_definitions(self):
-        with open('bibtexparser/tests/data/article_with_strings.bib', 'r') as bibfile:
+        with open('bibtexparser/tests/data/article_with_strings.bib', 'r',
+                  encoding="utf-8") as bibfile:
             bib = BibTexParser(bibfile.read(), common_strings=True)
         res = dict(bib.strings)
         expected = COMMON_STRINGS.copy()
@@ -564,7 +569,8 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_string_is_interpolated(self):
-        with open('bibtexparser/tests/data/article_with_strings.bib', 'r') as bibfile:
+        with open('bibtexparser/tests/data/article_with_strings.bib', 'r',
+                  encoding="utf-8") as bibfile:
             bib = BibTexParser(bibfile.read(), common_strings=True,
                                interpolate_strings=True)
         res = bib.get_entry_list()
@@ -584,7 +590,8 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_string_is_not_interpolated(self):
-        with open('bibtexparser/tests/data/article_with_strings.bib', 'r') as bibfile:
+        with open('bibtexparser/tests/data/article_with_strings.bib', 'r',
+                  encoding="utf-8") as bibfile:
             bib = BibTexParser(bibfile.read(), common_strings=True,
                                interpolate_strings=False)
         res = bib.get_entry_list()[0]


### PR DESCRIPTION
Currently, the tests depend on the system they are run on, in terms of assumed file encoding. 
This leads to tests that pass on the CI, but fail locally. 

This PR makes the encodings in the test files explicit.