### PR TITLE
:wrench: using common strings is now the default

### DIFF
--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -74,7 +74,7 @@ class BibTexParser(object):
                  ignore_nonstandard_types=True,
                  homogenize_fields=False,
                  interpolate_strings=True,
-                 common_strings=False,
+                 common_strings=True,
                  add_missing_from_crossref=False):
         """
         Creates a parser for reading BibTeX files
@@ -85,7 +85,7 @@ class BibTexParser(object):
         self.bib_database = BibDatabase()
 
         #: Load common strings such as months abbreviation
-        #: Default: `False`.
+        #: Default: `True` (new in 1.4.0 - was previously `False`)
         self.common_strings = common_strings
         if self.common_strings:
             self.bib_database.load_common_strings()

--- a/bibtexparser/tests/test_bibtex_strings.py
+++ b/bibtexparser/tests/test_bibtex_strings.py
@@ -12,24 +12,28 @@ from collections import OrderedDict
 class TestStringParse(unittest.TestCase):
 
     def test_single_string_parse_count(self):
+        parser = BibTexParser(common_strings=False)
         bibtex_str = '@string{name1 = "value1"}\n\n'
-        bib_database = bibtexparser.loads(bibtex_str)
+        bib_database = bibtexparser.loads(bibtex_str, parser)
         self.assertEqual(len(bib_database.strings), 1)
 
     def test_multiple_string_parse_count(self):
+        parser = BibTexParser(common_strings=False)
         bibtex_str = '@string{name1 = "value1"}\n\n@string{name2 = "value2"}\n\n'
-        bib_database = bibtexparser.loads(bibtex_str)
+        bib_database = bibtexparser.loads(bibtex_str, parser)
         self.assertEqual(len(bib_database.strings), 2)
 
     def test_single_string_parse(self):
+        parser = BibTexParser(common_strings=False)
         bibtex_str = '@string{name1 = "value1"}\n\n'
-        bib_database = bibtexparser.loads(bibtex_str)
+        bib_database = bibtexparser.loads(bibtex_str, parser)
         expected = {'name1': 'value1'}
         self.assertEqual(bib_database.strings, expected)
 
     def test_multiple_string_parse(self):
+        parser = BibTexParser(common_strings=False)
         bibtex_str = '@string{name1 = "value1"}\n\n@string{name2 = "value2"}\n\n'
-        bib_database = bibtexparser.loads(bibtex_str)
+        bib_database = bibtexparser.loads(bibtex_str, parser)
         expected = OrderedDict()
         expected['name1'] = 'value1'
         expected['name2'] = 'value2'
@@ -50,8 +54,9 @@ class TestStringParse(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_string_parse_accept_chars(self):
+        parser = BibTexParser(common_strings=False)
         bibtex_str = '@string{pub-ieee-std = {IEEE}}\n\n@string{pub-ieee-std:adr = {New York, NY, USA}}'
-        bib_database = bibtexparser.loads(bibtex_str)
+        bib_database = bibtexparser.loads(bibtex_str, parser)
         self.assertEqual(len(bib_database.strings), 2)
         expected = OrderedDict()
         expected['pub-ieee-std'] = 'IEEE'

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -56,7 +56,7 @@ def customizations_latex(record):
 class TestBibtexParserList(unittest.TestCase):
 
     def test_empty_string(self):
-        bib = BibTexParser("")
+        bib = BibTexParser("", common_strings=False)
         self.assertEqual(bib.entries, [])
         self.assertEqual(bib.comments, [])
         self.assertEqual(bib.preambles, [])
@@ -633,7 +633,7 @@ class TestBibtexParserList(unittest.TestCase):
           like = a = bibtex file but
               , is not a real one!
         '''
-        parser = BibTexParser()
+        parser = BibTexParser(common_strings=False)
         bib = parser.parse(bibraw, partial=False)
         self.assertEqual(bib.entries, [])
         self.assertEqual(bib.preambles, [])
@@ -644,7 +644,7 @@ class TestBibtexParserList(unittest.TestCase):
             '              , is not a real one!'])
 
     def test_no_citekey_parsed_as_comment(self):
-        bib = BibTexParser('@BOOK{, title = "bla"}')
+        bib = BibTexParser('@BOOK{, title = "bla"}', common_strings=False)
         self.assertEqual(bib.entries, [])
         self.assertEqual(bib.preambles, [])
         self.assertEqual(bib.strings, {})

--- a/bibtexparser/tests/test_comments.py
+++ b/bibtexparser/tests/test_comments.py
@@ -131,7 +131,7 @@ Sunt in culpa qui officia deserunt mollit anim id est laborum.
                   "This is a comment\n" \
                   "This is a second comment."
         expected = "This is a comment\nThis is a second comment."
-        bib = BibTexParser(comment)
+        bib = BibTexParser(comment, common_strings=False)
         self.assertEqual(bib.comments, [expected])
         self.assertEqual(bib.strings, {'foo': 'bar'})
 
@@ -141,7 +141,7 @@ Sunt in culpa qui officia deserunt mollit anim id est laborum.
                   "STRING{Baz = \"This should be interpreted as comment.\"}"
         expected = "This is a comment\n" \
                    "STRING{Baz = \"This should be interpreted as comment.\"}"
-        bib = BibTexParser(comment)
+        bib = BibTexParser(comment, common_strings=False)
         self.assertEqual(bib.comments, [expected])
         self.assertEqual(bib.strings, {'foo': 'bar'})
 


### PR DESCRIPTION
Having to manually enable common strings appears to be one of the biggest unexpected behaviors, leading to plenty of questions.

Making the use of common strings a default does not fix all problems (e.g., people wanting to get non-interpolated, string values), but it should be a crucial first step and - most importantly - makes the default config more natural and intuitive for new users.

Not many negative side effects are expected from this. The old behavior can easily be enabled by creating a parser with `common_strings=False`

Fixes #280
Fixes #263
Fixes #248