### PR TITLE
:children_crossing: Raise warning if parser is used multiple times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ nosetests.xml
 
 # Vim.
 *.swp
+
+# Vscode
+.vscode

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -150,9 +150,10 @@ class BibTexParser(object):
 
         self._parse_call_count += 1
         if self._parse_call_count == 2 and not self.expect_multiple_parse:
-            warnings.warn("Parser has been called more than once, "
-                          "avoid the warning by setting property expect_multiple_parse to True.", category=UserWarning,
-                          stacklevel=2)
+            warnings.warn("The parser has been called more than once. "
+                          "Subsequent parse calls lead to a combined BibTeX library. \n"
+                          "To avoid the warning, set property `parser.expect_multiple_parse` to `True`.",
+                          category=UserWarning, stacklevel=2)
 
         bibtex_file_obj = self._bibtex_file_obj(bibtex_str)
         try:

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -85,6 +85,8 @@ class BibTexParser(object):
         """
 
         self._parse_call_count = 0
+        #: Parsers can be called multiple times, merging databases, but raising a warning.
+        #      Set this to `True` to disable the warning. Default: `False`
         self.expect_multiple_parse = False
 
         self.bib_database = BibDatabase()

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -138,6 +138,7 @@ class BibTexParser(object):
 
     def parse(self, bibtex_str, partial=False):
         """Parse a BibTeX string into an object
+
         :param bibtex_str: BibTeX string
         :type: str or unicode
         :param partial: If True, print errors only on parsing failures.
@@ -188,7 +189,7 @@ class BibTexParser(object):
         # Handle string as BibDataString object
         self._expr.set_string_name_parse_action(
             lambda s, l, t:
-            BibDataString(self.bib_database, t[0]))
+                BibDataString(self.bib_database, t[0]))
 
         # Add notice to logger
         self._expr.add_log_function(logger.debug)
@@ -197,20 +198,20 @@ class BibTexParser(object):
         self._expr.entry.addParseAction(
             lambda s, l, t: self._add_entry(
                 t.get('EntryType'), t.get('Key'), t.get('Fields'))
-        )
+            )
         self._expr.implicit_comment.addParseAction(
             lambda s, l, t: self._add_comment(t[0])
-        )
+            )
         self._expr.explicit_comment.addParseAction(
             lambda s, l, t: self._add_comment(t[0])
-        )
+            )
         self._expr.preamble_decl.addParseAction(
             lambda s, l, t: self._add_preamble(t[0])
-        )
+            )
         self._expr.string_def.addParseAction(
             lambda s, l, t: self._add_string(t['StringName'].name,
                                              t['StringValue'])
-        )
+            )
 
     def _bibtex_file_obj(self, bibtex_str):
         # Some files have Byte-order marks inserted at the start

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -76,7 +76,8 @@ class BibTexParser(object):
                  homogenize_fields=False,
                  interpolate_strings=True,
                  common_strings=True,
-                 add_missing_from_crossref=False):
+                 add_missing_from_crossref=False,
+                 expect_multiple_parse=False):
         """
         Creates a parser for reading BibTeX files
 
@@ -84,7 +85,9 @@ class BibTexParser(object):
         :rtype: `BibTexParser`
         """
 
+        self.expect_multiple_parse = expect_multiple_parse
         self._parse_call_count = 0
+
         self.bib_database = BibDatabase()
 
         #: Load common strings such as months abbreviation
@@ -134,7 +137,7 @@ class BibTexParser(object):
         # Setup the parser expression
         self._init_expressions()
 
-    def parse(self, bibtex_str, partial=False, expect_multiple_parse=False):
+    def parse(self, bibtex_str, partial=False):
         """Parse a BibTeX string into an object
         :param expect_multiple_parse: if True, does not print warnings
         :param bibtex_str: BibTeX string
@@ -148,7 +151,7 @@ class BibTexParser(object):
 
         self._parse_call_count += 1
         call_counter = self._parse_call_count
-        if call_counter > 1 and not expect_multiple_parse:
+        if call_counter > 1 and not self.expect_multiple_parse:
             warnings.warn("parser has been called more than once")
 
         bibtex_file_obj = self._bibtex_file_obj(bibtex_str)

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -83,6 +83,8 @@ class BibTexParser(object):
         :return: parser
         :rtype: `BibTexParser`
         """
+
+        self._parse_call_count = 0
         self.bib_database = BibDatabase()
 
         #: Load common strings such as months abbreviation
@@ -144,9 +146,10 @@ class BibTexParser(object):
         :rtype: BibDatabase
         """
 
-        call_counter = self.__parse_call_count
+        self._parse_call_count += 1
+        call_counter = self._parse_call_count
         if call_counter > 1 and not expect_multiple_parse:
-            warnings.warn("Parser has been called more than once.")
+            warnings.warn("parser has been called more than once")
 
         bibtex_file_obj = self._bibtex_file_obj(bibtex_str)
         try:

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -8,6 +8,7 @@
 
 import io
 import logging
+import warnings
 
 from bibtexparser.bibdatabase import (BibDatabase, BibDataString, as_text,
                                       BibDataStringExpression, STANDARD_TYPES)
@@ -131,9 +132,9 @@ class BibTexParser(object):
         # Setup the parser expression
         self._init_expressions()
 
-    def parse(self, bibtex_str, partial=False):
+    def parse(self, bibtex_str, partial=False, expect_multiple_parse=False):
         """Parse a BibTeX string into an object
-
+        :param expect_multiple_parse: if True, does not print warnings
         :param bibtex_str: BibTeX string
         :type: str or unicode
         :param partial: If True, print errors only on parsing failures.
@@ -142,6 +143,11 @@ class BibTexParser(object):
         :return: bibliographic database
         :rtype: BibDatabase
         """
+
+        call_counter = self.__parse_call_count
+        if call_counter > 1 and not expect_multiple_parse:
+            warnings.warn("Parser has been called more than once.")
+
         bibtex_file_obj = self._bibtex_file_obj(bibtex_str)
         try:
             self._expr.parseFile(bibtex_file_obj)

--- a/bibtexparser/tests/data/article_comma_normal_multiple.bib
+++ b/bibtexparser/tests/data/article_comma_normal_multiple.bib
@@ -1,0 +1,42 @@
+@article{FuMetalhalideperovskite2019,
+    author = {Yongping Fu and Haiming Zhu and Jie Chen and Matthew P. Hautzinger and X.-Y. Zhu and Song Jin},
+    doi = {10.1038/s41578-019-0080-9},
+    journal = {Nature Reviews Materials},
+    month = {feb},
+    number = {3},
+    pages = {169-188},
+    publisher = {Springer Science and Business Media {LLC}},
+    title = {Metal halide perovskite nanostructures for optoelectronic applications and the study of physical properties},
+    url = {https://www.nature.com/articles/s41578-019-0080-9},
+    volume = {4},
+    year = {2019}
+}
+
+@article{SunEnablingSiliconSolar2014,
+    author = {Ke Sun and Shaohua Shen and Yongqi Liang and Paul E. Burrows and Samuel S. Mao and Deli Wang},
+    doi = {10.1021/cr300459q},
+    journal = {Chemical Reviews},
+    month = {aug},
+    number = {17},
+    pages = {8662-8719},
+    publisher = {American Chemical Society ({ACS})},
+    title = {Enabling Silicon for Solar-Fuel Production},
+    url = {http://pubs.acs.org/doi/10.1021/cr300459q},
+    volume = {114},
+    year = {2014}
+}
+
+@article{LiuPhotocatalytichydrogenproduction2016,
+    author = {Maochang Liu and Yubin Chen and Jinzhan Su and Jinwen Shi and Xixi Wang and Liejin Guo},
+    doi = {10.1038/nenergy.2016.151},
+    impactfactor = {54.000},
+    journal = {Nature Energy},
+    month = {sep},
+    number = {11},
+    pages = {16151},
+    publisher = {Springer Science and Business Media {LLC}},
+    title = {Photocatalytic hydrogen production using twinned nanocrystals and an unanchored {NiSx} co-catalyst},
+    url = {http://www.nature.com/articles/nenergy2016151},
+    volume = {1},
+    year = {2016}
+}

--- a/bibtexparser/tests/data/article_comma_normal_single.bib
+++ b/bibtexparser/tests/data/article_comma_normal_single.bib
@@ -1,0 +1,13 @@
+@article{FuMetalhalideperovskite2019,
+    author = {Yongping Fu and Haiming Zhu and Jie Chen and Matthew P. Hautzinger and X.-Y. Zhu and Song Jin},
+    doi = {10.1038/s41578-019-0080-9},
+    journal = {Nature Reviews Materials},
+    month = {feb},
+    number = {3},
+    pages = {169-188},
+    publisher = {Springer Science and Business Media {LLC}},
+    title = {Metal halide perovskite nanostructures for optoelectronic applications and the study of physical properties},
+    url = {https://www.nature.com/articles/s41578-019-0080-9},
+    volume = {4},
+    year = {2019}
+}

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -6,7 +6,9 @@ from __future__ import unicode_literals
 import os
 import unittest
 import codecs
+import warnings
 
+import bibtexparser
 from bibtexparser.bparser import BibTexParser
 from bibtexparser.bibdatabase import (COMMON_STRINGS, BibDataStringExpression)
 from bibtexparser.customization import *
@@ -85,18 +87,18 @@ class TestBibtexParserList(unittest.TestCase):
                               'month': 'jan'
                               }]
             expected_dict = {'Cesar2013': {'keyword': 'keyword1, keyword2',
-                              'ENTRYTYPE': 'article',
-                              'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
-                              'year': '2013',
-                              'journal': 'Nice Journal',
-                              'ID': 'Cesar2013',
-                              'pages': '12-23',
-                              'title': 'An amazing title',
-                              'comments': 'A comment',
-                              'author': 'Jean César',
-                              'volume': '12',
-                              'month': 'jan'
-                              }}
+                                           'ENTRYTYPE': 'article',
+                                           'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+                                           'year': '2013',
+                                           'journal': 'Nice Journal',
+                                           'ID': 'Cesar2013',
+                                           'pages': '12-23',
+                                           'title': 'An amazing title',
+                                           'comments': 'A comment',
+                                           'author': 'Jean César',
+                                           'volume': '12',
+                                           'month': 'jan'
+                                           }}
         self.assertEqual(res_list, expected_list)
         self.assertEqual(res_dict, expected_dict)
 
@@ -140,57 +142,60 @@ class TestBibtexParserList(unittest.TestCase):
         with codecs.open('bibtexparser/tests/data/article_start_with_bom.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read())
             res = bib.get_entry_list()
-        expected = [{'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
-                     'ENTRYTYPE': 'article',
-                     'pages': '12-23',
-                     'volume': '12',
-                     'ID': 'Cesar2013',
-                     'year': '2013',
-                     'author': 'Jean César',
-                     'journal': 'Nice Journal',
-                     'comments': 'A comment',
-                     'month': 'jan',
-                     'keyword': 'keyword1, keyword2',
-                     'title': 'An amazing title'
-                     }]
+        expected = [{
+            'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+            'ENTRYTYPE': 'article',
+            'pages': '12-23',
+            'volume': '12',
+            'ID': 'Cesar2013',
+            'year': '2013',
+            'author': 'Jean César',
+            'journal': 'Nice Journal',
+            'comments': 'A comment',
+            'month': 'jan',
+            'keyword': 'keyword1, keyword2',
+            'title': 'An amazing title'
+        }]
         self.assertEqual(res, expected)
 
     def test_article_cust_unicode(self):
         with codecs.open('bibtexparser/tests/data/article.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read(), customization=customizations_unicode)
             res = bib.get_entry_list()
-        expected = [{'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
-                     'ENTRYTYPE': 'article',
-                     'pages': '12--23',
-                     'volume': '12',
-                     'ID': 'Cesar2013',
-                     'year': '2013',
-                     'author': ['César, Jean'],
-                     'journal': {'ID': 'NiceJournal', 'name': 'Nice Journal'},
-                     'comments': 'A comment',
-                     'month': 'jan',
-                     'keyword': ['keyword1', 'keyword2'],
-                     'title': 'An amazing title'
-                     }]
+        expected = [{
+            'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+            'ENTRYTYPE': 'article',
+            'pages': '12--23',
+            'volume': '12',
+            'ID': 'Cesar2013',
+            'year': '2013',
+            'author': ['César, Jean'],
+            'journal': {'ID': 'NiceJournal', 'name': 'Nice Journal'},
+            'comments': 'A comment',
+            'month': 'jan',
+            'keyword': ['keyword1', 'keyword2'],
+            'title': 'An amazing title'
+        }]
         self.assertEqual(res, expected)
 
     def test_article_cust_latex(self):
         with codecs.open('bibtexparser/tests/data/article.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read(), customization=customizations_latex)
             res = bib.get_entry_list()
-        expected = [{'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french {\\\'e}rudit word',
-                     'ENTRYTYPE': 'article',
-                     'pages': '12--23',
-                     'volume': '12',
-                     'ID': 'Cesar2013',
-                     'year': '2013',
-                     'author': ['C{\\\'e}sar, Jean'],
-                     'journal': {'ID': 'NiceJournal', 'name': 'Nice Journal'},
-                     'comments': 'A comment',
-                     'month': 'jan',
-                     'keyword': ['keyword1', 'keyword2'],
-                     'title': '{A}n amazing title'
-                     }]
+        expected = [{
+            'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french {\\\'e}rudit word',
+            'ENTRYTYPE': 'article',
+            'pages': '12--23',
+            'volume': '12',
+            'ID': 'Cesar2013',
+            'year': '2013',
+            'author': ['C{\\\'e}sar, Jean'],
+            'journal': {'ID': 'NiceJournal', 'name': 'Nice Journal'},
+            'comments': 'A comment',
+            'month': 'jan',
+            'keyword': ['keyword1', 'keyword2'],
+            'title': '{A}n amazing title'
+        }]
         self.assertEqual(res, expected)
 
     def test_article_cust_order(self):
@@ -287,7 +292,6 @@ class TestBibtexParserList(unittest.TestCase):
                      }]
         self.assertEqual(res, expected)
 
-
     def test_article_start_with_whitespace(self):
         with open('bibtexparser/tests/data/article_start_with_whitespace.bib', 'r') as bibfile:
             bib = BibTexParser(bibfile.read())
@@ -337,7 +341,7 @@ class TestBibtexParserList(unittest.TestCase):
                      'title': 'An amazing title',
                      'abstract': "This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word",
                      },
-                     ]
+                    ]
         self.assertEqual(res, expected)
 
     def test_article_special_characters(self):
@@ -358,7 +362,7 @@ class TestBibtexParserList(unittest.TestCase):
                      'title': 'An amazing title',
                      'abstract': "This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word",
                      },
-                     ]
+                    ]
         self.assertEqual(res, expected)
 
     def test_article_protection_braces(self):
@@ -379,9 +383,8 @@ class TestBibtexParserList(unittest.TestCase):
                      'title': '{An amazing title}',
                      'abstract': "This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word",
                      },
-                     ]
+                    ]
         self.assertEqual(res, expected)
-
 
     ###########
     # BOOK
@@ -552,7 +555,7 @@ class TestBibtexParserList(unittest.TestCase):
             'volume': '12',
             'strange_field_name': 'val',
             'strange-field-name2': 'val2',
-            }]
+        }]
         self.assertEqual(res, expected)
 
     def test_string_definitions(self):
@@ -562,10 +565,10 @@ class TestBibtexParserList(unittest.TestCase):
         res = dict(bib.strings)
         expected = COMMON_STRINGS.copy()
         expected.update({
-                'nice_journal': 'Nice Journal',
-                'jean': 'Jean',
-                'cesar': "César",
-                })
+            'nice_journal': 'Nice Journal',
+            'jean': 'Jean',
+            'cesar': "César",
+        })
         self.assertEqual(res, expected)
 
     def test_string_is_interpolated(self):
@@ -586,7 +589,7 @@ class TestBibtexParserList(unittest.TestCase):
             'comments': 'A comment',
             'author': 'Jean César',
             'volume': '12',
-            }]
+        }]
         self.assertEqual(res, expected)
 
     def test_string_is_not_interpolated(self):
@@ -607,8 +610,8 @@ class TestBibtexParserList(unittest.TestCase):
 
     def test_comments_spaces_and_declarations(self):
         with codecs.open(
-                'bibtexparser/tests/data/comments_spaces_and_declarations.bib',
-                'r', 'utf-8') as bibfile:
+            'bibtexparser/tests/data/comments_spaces_and_declarations.bib',
+            'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read())
         res_dict = bib.get_entry_dict()
         expected_dict = {'Cesar2013': {
@@ -649,6 +652,60 @@ class TestBibtexParserList(unittest.TestCase):
         self.assertEqual(bib.preambles, [])
         self.assertEqual(bib.strings, {})
         self.assertEqual(bib.comments, ['@BOOK{, title = "bla"}'])
+
+    def test_parsing_just_once_not_raising_warnings_with_default_settings(self):
+        parser = BibTexParser()
+
+        with open('bibtexparser/tests/data/article_comma_normal_single.bib',
+                  'r', encoding='utf-8') as bibfile:
+            with warnings.catch_warnings(record=True) as warning:
+                warnings.simplefilter("always")
+                bibtexparser.load(bibfile, parser)
+                assert len(warning) == 0
+
+    def test_parsing_twice_raise_warnings_with_default_settings(self):
+        parser = BibTexParser()
+
+        with open('bibtexparser/tests/data/article_comma_normal_single.bib',
+                  'r', encoding='utf-8') as bibfile_first, \
+            open('bibtexparser/tests/data/article_comma_normal_multiple.bib', 'r', encoding='utf-8') \
+                as bibfile_second:
+            with warnings.catch_warnings(record=True) as warning:
+                warnings.simplefilter("always")
+                bibtexparser.load(bibfile_first, parser)
+                bibtexparser.load(bibfile_second, parser)
+                assert len(warning) != 0
+
+    def test_parsing_three_times_raise_warnings_only_once_with_default_settings(self):
+        parser = BibTexParser()
+
+        with open('bibtexparser/tests/data/article_comma_normal_single.bib',
+                  'r', encoding='utf-8') as bibfile_first, \
+            open('bibtexparser/tests/data/article_comma_normal_multiple.bib', 'r', encoding='utf-8') \
+                as bibfile_second, \
+                open('bibtexparser/tests/data/article.bib', 'r', encoding='utf-8') as bibfile_third:
+            with warnings.catch_warnings(record=True) as warning:
+                warnings.simplefilter("always")
+                bibtexparser.load(bibfile_first, parser)
+                bibtexparser.load(bibfile_second, parser)
+                bibtexparser.load(bibfile_third, parser)
+                assert len(warning) == 1
+
+    def test_parsing_three_times_not_raising_a_warning_if_expect_multiple_parse_is_true(self):
+        parser = BibTexParser()
+        parser.expect_multiple_parse = True
+
+        with open('bibtexparser/tests/data/article_comma_normal_single.bib',
+                  'r', encoding='utf-8') as bibfile_first, \
+            open('bibtexparser/tests/data/article_comma_normal_multiple.bib', 'r', encoding='utf-8') \
+                as bibfile_second, \
+                open('bibtexparser/tests/data/article.bib', 'r', encoding='utf-8') as bibfile_third:
+            with warnings.catch_warnings(record=True) as warning:
+                warnings.simplefilter("always")
+                bibtexparser.load(bibfile_first, parser)
+                bibtexparser.load(bibfile_second, parser)
+                bibtexparser.load(bibfile_third, parser)
+                assert len(warning) == 0
 
 
 if __name__ == '__main__':

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -87,18 +87,18 @@ class TestBibtexParserList(unittest.TestCase):
                               'month': 'jan'
                               }]
             expected_dict = {'Cesar2013': {'keyword': 'keyword1, keyword2',
-                                           'ENTRYTYPE': 'article',
-                                           'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
-                                           'year': '2013',
-                                           'journal': 'Nice Journal',
-                                           'ID': 'Cesar2013',
-                                           'pages': '12-23',
-                                           'title': 'An amazing title',
-                                           'comments': 'A comment',
-                                           'author': 'Jean César',
-                                           'volume': '12',
-                                           'month': 'jan'
-                                           }}
+                              'ENTRYTYPE': 'article',
+                              'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+                              'year': '2013',
+                              'journal': 'Nice Journal',
+                              'ID': 'Cesar2013',
+                              'pages': '12-23',
+                              'title': 'An amazing title',
+                              'comments': 'A comment',
+                              'author': 'Jean César',
+                              'volume': '12',
+                              'month': 'jan'
+                              }}
         self.assertEqual(res_list, expected_list)
         self.assertEqual(res_dict, expected_dict)
 
@@ -339,7 +339,7 @@ class TestBibtexParserList(unittest.TestCase):
                      'title': 'An amazing title',
                      'abstract': "This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word",
                      },
-                    ]
+                     ]
         self.assertEqual(res, expected)
 
     def test_article_special_characters(self):
@@ -360,7 +360,7 @@ class TestBibtexParserList(unittest.TestCase):
                      'title': 'An amazing title',
                      'abstract': "This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word",
                      },
-                    ]
+                     ]
         self.assertEqual(res, expected)
 
     def test_article_protection_braces(self):
@@ -381,7 +381,7 @@ class TestBibtexParserList(unittest.TestCase):
                      'title': '{An amazing title}',
                      'abstract': "This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word",
                      },
-                    ]
+                     ]
         self.assertEqual(res, expected)
 
 
@@ -554,7 +554,7 @@ class TestBibtexParserList(unittest.TestCase):
             'volume': '12',
             'strange_field_name': 'val',
             'strange-field-name2': 'val2',
-        }]
+            }]
         self.assertEqual(res, expected)
 
     def test_string_definitions(self):
@@ -564,10 +564,10 @@ class TestBibtexParserList(unittest.TestCase):
         res = dict(bib.strings)
         expected = COMMON_STRINGS.copy()
         expected.update({
-            'nice_journal': 'Nice Journal',
-            'jean': 'Jean',
-            'cesar': "César",
-        })
+                'nice_journal': 'Nice Journal',
+                'jean': 'Jean',
+                'cesar': "César",
+                })
         self.assertEqual(res, expected)
 
     def test_string_is_interpolated(self):
@@ -588,7 +588,7 @@ class TestBibtexParserList(unittest.TestCase):
             'comments': 'A comment',
             'author': 'Jean César',
             'volume': '12',
-        }]
+            }]
         self.assertEqual(res, expected)
 
     def test_string_is_not_interpolated(self):
@@ -609,8 +609,8 @@ class TestBibtexParserList(unittest.TestCase):
 
     def test_comments_spaces_and_declarations(self):
         with codecs.open(
-            'bibtexparser/tests/data/comments_spaces_and_declarations.bib',
-            'r', 'utf-8') as bibfile:
+                'bibtexparser/tests/data/comments_spaces_and_declarations.bib',
+                'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read())
         res_dict = bib.get_entry_dict()
         expected_dict = {'Cesar2013': {

--- a/bibtexparser/tests/test_bparser.py
+++ b/bibtexparser/tests/test_bparser.py
@@ -142,60 +142,57 @@ class TestBibtexParserList(unittest.TestCase):
         with codecs.open('bibtexparser/tests/data/article_start_with_bom.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read())
             res = bib.get_entry_list()
-        expected = [{
-            'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
-            'ENTRYTYPE': 'article',
-            'pages': '12-23',
-            'volume': '12',
-            'ID': 'Cesar2013',
-            'year': '2013',
-            'author': 'Jean César',
-            'journal': 'Nice Journal',
-            'comments': 'A comment',
-            'month': 'jan',
-            'keyword': 'keyword1, keyword2',
-            'title': 'An amazing title'
-        }]
+        expected = [{'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+                     'ENTRYTYPE': 'article',
+                     'pages': '12-23',
+                     'volume': '12',
+                     'ID': 'Cesar2013',
+                     'year': '2013',
+                     'author': 'Jean César',
+                     'journal': 'Nice Journal',
+                     'comments': 'A comment',
+                     'month': 'jan',
+                     'keyword': 'keyword1, keyword2',
+                     'title': 'An amazing title'
+                     }]
         self.assertEqual(res, expected)
 
     def test_article_cust_unicode(self):
         with codecs.open('bibtexparser/tests/data/article.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read(), customization=customizations_unicode)
             res = bib.get_entry_list()
-        expected = [{
-            'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
-            'ENTRYTYPE': 'article',
-            'pages': '12--23',
-            'volume': '12',
-            'ID': 'Cesar2013',
-            'year': '2013',
-            'author': ['César, Jean'],
-            'journal': {'ID': 'NiceJournal', 'name': 'Nice Journal'},
-            'comments': 'A comment',
-            'month': 'jan',
-            'keyword': ['keyword1', 'keyword2'],
-            'title': 'An amazing title'
-        }]
+        expected = [{'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french érudit word',
+                     'ENTRYTYPE': 'article',
+                     'pages': '12--23',
+                     'volume': '12',
+                     'ID': 'Cesar2013',
+                     'year': '2013',
+                     'author': ['César, Jean'],
+                     'journal': {'ID': 'NiceJournal', 'name': 'Nice Journal'},
+                     'comments': 'A comment',
+                     'month': 'jan',
+                     'keyword': ['keyword1', 'keyword2'],
+                     'title': 'An amazing title'
+                     }]
         self.assertEqual(res, expected)
 
     def test_article_cust_latex(self):
         with codecs.open('bibtexparser/tests/data/article.bib', 'r', 'utf-8') as bibfile:
             bib = BibTexParser(bibfile.read(), customization=customizations_latex)
             res = bib.get_entry_list()
-        expected = [{
-            'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french {\\\'e}rudit word',
-            'ENTRYTYPE': 'article',
-            'pages': '12--23',
-            'volume': '12',
-            'ID': 'Cesar2013',
-            'year': '2013',
-            'author': ['C{\\\'e}sar, Jean'],
-            'journal': {'ID': 'NiceJournal', 'name': 'Nice Journal'},
-            'comments': 'A comment',
-            'month': 'jan',
-            'keyword': ['keyword1', 'keyword2'],
-            'title': '{A}n amazing title'
-        }]
+        expected = [{'abstract': 'This is an abstract. This line should be long enough to test\nmultilines... and with a french {\\\'e}rudit word',
+                     'ENTRYTYPE': 'article',
+                     'pages': '12--23',
+                     'volume': '12',
+                     'ID': 'Cesar2013',
+                     'year': '2013',
+                     'author': ['C{\\\'e}sar, Jean'],
+                     'journal': {'ID': 'NiceJournal', 'name': 'Nice Journal'},
+                     'comments': 'A comment',
+                     'month': 'jan',
+                     'keyword': ['keyword1', 'keyword2'],
+                     'title': '{A}n amazing title'
+                     }]
         self.assertEqual(res, expected)
 
     def test_article_cust_order(self):
@@ -292,6 +289,7 @@ class TestBibtexParserList(unittest.TestCase):
                      }]
         self.assertEqual(res, expected)
 
+
     def test_article_start_with_whitespace(self):
         with open('bibtexparser/tests/data/article_start_with_whitespace.bib', 'r') as bibfile:
             bib = BibTexParser(bibfile.read())
@@ -385,6 +383,7 @@ class TestBibtexParserList(unittest.TestCase):
                      },
                     ]
         self.assertEqual(res, expected)
+
 
     ###########
     # BOOK


### PR DESCRIPTION
Fixes https://github.com/sciunto-org/python-bibtexparser/issues/308. A warning message will appear if the `parse` method is called more than once and the message will be "Parser has been called more than once."