### PR TITLE
:sparkles: Model dunder methods

### DIFF
--- a/bibtexparser/model.py
+++ b/bibtexparser/model.py
@@ -2,9 +2,6 @@ import abc
 from typing import Any, Dict, List, Optional
 
 
-# TODO Overwrite copy and deepcopy dundermethods
-
-
 class Block(abc.ABC):
     def __init__(self,
                  start_line: int,
@@ -27,6 +24,12 @@ class Block(abc.ABC):
     @property
     def parser_metadata(self) -> Dict[str, Any]:
         return self._parser_metadata
+
+    def __eq__(self, other):
+        # make sure they have the same type and same content
+        return (isinstance(other, self.__class__) and
+                isinstance(self, other.__class__) and
+                self.__dict__ == other.__dict__)
 
 
 class String(Block):
@@ -129,6 +132,12 @@ class Field:
     @property
     def start_line(self) -> int:
         return self._start_line
+
+    def __eq__(self, other):
+        # make sure they have the same type and same content
+        return (isinstance(other, self.__class__) and
+                isinstance(self, other.__class__) and
+                self.__dict__ == other.__dict__)
 
 
 class Entry(Block):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,178 @@
+from copy import copy, deepcopy
+
+from bibtexparser.model import Field, Entry, String, Preamble, ImplicitComment, ExplicitComment
+
+
+def test_entry_equality():
+    # Equal to itself
+    entry_1 = Entry(1, 'raw', 'article', 'key', {'field': Field(1, 'field', 'value')})
+    assert entry_1 == entry_1
+    # Equal to identical entry
+    entry_2 = Entry(1, 'raw', 'article', 'key', {'field': Field(1, 'field', 'value')})
+    assert entry_1 == entry_2
+    # Not equal to entry with different entry-type
+    entry_3 = Entry(1, 'raw', 'book', 'key', {'field': Field(1, 'field', 'value')})
+    assert entry_1 != entry_3
+    # Not equal to entry with different fields
+    entry_4 = Entry(1, 'raw', 'article', 'key', {'field': Field(1, 'field', 'value'),
+                                                 'field2': Field(1, 'field2', 'value')})
+    assert entry_1 != entry_4
+
+
+def test_entry_copy():
+    entry_1 = Entry(1, 'raw', 'article', 'key', {'field': Field(1, 'field', 'value')})
+    entry_2 = copy(entry_1)
+    assert entry_1 == entry_2
+    assert entry_1 is not entry_2
+    assert entry_1.fields is entry_2.fields
+    assert entry_1.fields == entry_2.fields
+
+
+def test_entry_deepcopy():
+    entry_1 = Entry(1, 'raw', 'article', 'key', {'field': Field(1, 'field', 'value')})
+    entry_2 = deepcopy(entry_1)
+    assert entry_1 == entry_2
+    assert entry_1 is not entry_2
+    assert entry_1.fields is not entry_2.fields
+    assert entry_1.fields == entry_2.fields
+    assert entry_1.fields['field'] is not entry_2.fields['field']
+    assert entry_1.fields['field'] == entry_2.fields['field']
+
+
+def test_string_equality():
+    # Equal to itself
+    string_1 = String(1, 'raw', 'key', 'value')
+    assert string_1 == string_1
+    # Equal to identical string
+    string_2 = String(1, 'raw', 'key', 'value')
+    assert string_1 == string_2
+    # Not equal to string with different key
+    string_3 = String(1, 'raw', 'key2', 'value')
+    assert string_1 != string_3
+    # Not equal to string with different value
+    string_4 = String(1, 'raw', 'key', 'value2')
+    assert string_1 != string_4
+
+
+def test_string_copy():
+    string_1 = String(1, 'raw', 'key', 'value')
+    string_2 = copy(string_1)
+    assert string_1 == string_2
+    assert string_1 is not string_2
+
+
+def test_string_deepcopy():
+    string_1 = String(1, 'raw', 'key', 'value')
+    string_2 = deepcopy(string_1)
+    assert string_1 == string_2
+    assert string_1 is not string_2
+
+
+def test_preamble_equality():
+    # Equal to itself
+    preamble_1 = Preamble(1, 'raw', 'value')
+    assert preamble_1 == preamble_1
+    # Equal to identical preamble
+    preamble_2 = Preamble(1, 'raw', 'value')
+    assert preamble_1 == preamble_2
+    # Not equal to preamble with different value
+    preamble_3 = Preamble(1, 'raw', 'value2')
+    assert preamble_1 != preamble_3
+
+
+def test_preamble_copy():
+    preamble_1 = Preamble(1, 'raw', 'value')
+    preamble_2 = copy(preamble_1)
+    assert preamble_1 == preamble_2
+    assert preamble_1 is not preamble_2
+
+
+def test_preable_deepcopy():
+    preamble_1 = Preamble(1, 'raw', 'value')
+    preamble_2 = deepcopy(preamble_1)
+    assert preamble_1 == preamble_2
+    assert preamble_1 is not preamble_2
+
+
+def test_implicit_comment_equality():
+    # Equal to itself
+    comment_1 = ImplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    assert comment_1 == comment_1
+    # Equal to identical comment
+    comment_2 = ImplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    assert comment_1 == comment_2
+    # Not equal to comment with different comment
+    comment_3 = ImplicitComment(start_line=1,
+                                comment="This is my comment2",
+                                raw="#  This is my comment")
+    assert comment_1 != comment_3
+
+
+def test_implicit_comment_copy():
+    comment_1 = ImplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    comment_2 = copy(comment_1)
+    assert comment_1 == comment_2
+    assert comment_1 is not comment_2
+
+
+def test_implicit_comment_deepcopy():
+    comment_1 = ImplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    comment_2 = deepcopy(comment_1)
+    assert comment_1 == comment_2
+    assert comment_1 is not comment_2
+
+
+def test_explicit_comment_equality():
+    # Equal to itself
+    comment_1 = ExplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    assert comment_1 == comment_1
+    # Equal to identical comment
+    comment_2 = ExplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    assert comment_1 == comment_2
+    # Not equal to comment with different comment
+    comment_3 = ExplicitComment(start_line=1,
+                                comment="This is my comment2",
+                                raw="#  This is my comment")
+    assert comment_1 != comment_3
+
+
+def test_explicit_comment_copy():
+    comment_1 = ExplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    comment_2 = copy(comment_1)
+    assert comment_1 == comment_2
+    assert comment_1 is not comment_2
+
+
+def test_explicit_comment_deepcopy():
+    comment_1 = ExplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    comment_2 = deepcopy(comment_1)
+    assert comment_1 == comment_2
+    assert comment_1 is not comment_2
+
+
+def test_implicit_and_explicit_comment_equality():
+    # Equal to itself
+    comment_1 = ImplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    comment_2 = ExplicitComment(start_line=1,
+                                comment="This is my comment",
+                                raw="#  This is my comment")
+    assert comment_1 != comment_2
+    assert comment_2 != comment_1


### PR DESCRIPTION
Implement and test `==`, `copy` and `deepcopy` for blocks and fields.