### PR TITLE
Fix getnames to not tidy quoted author names

### DIFF
--- a/bibtexparser/tests/test_customization.py
+++ b/bibtexparser/tests/test_customization.py
@@ -31,6 +31,7 @@ class TestBibtexParserMethod(unittest.TestCase):
                  'Foo B{\'a}r',
                  r'{G{\'{e}}rard} {Ben Arous}',
                  'Incorrect {{name}',
+                 '{Company Inc.}',
                  #'Jean de la Tour',
                  #'Johannes Diderik van der Waals',
                  ]
@@ -53,6 +54,7 @@ class TestBibtexParserMethod(unittest.TestCase):
                     'B{\'a}r, Foo',
                     r'{Ben Arous}, {G{\'{e}}rard}',
                     'Incorrect {{name}',
+                    '{Company Inc.}',
                     #'de la Tour, Jean',
                     #'van der Waals, Johannes Diderik',
                     ]


### PR DESCRIPTION
The implementation of getnames currently does not special-case quoted author names so that a company name like `{Google Inc}` gets added to the tidynames list as `Inc}, {Google`. This PR fixes that so that `{Google Inc}` is added to the list unchanged.