### PR TITLE
solve name conflict

### DIFF
--- a/bibtexparser/entrypoint.py
+++ b/bibtexparser/entrypoint.py
@@ -5,7 +5,7 @@ from .library import Library
 from .middlewares.middleware import Middleware
 from .middlewares.parsestack import default_parse_stack, default_unparse_stack
 from .splitter import Splitter
-from .writer import BibtexFormat, write_string
+from .writer import BibtexFormat, write
 
 
 def _build_parse_stack(
@@ -165,4 +165,4 @@ def write_string(
     for middleware in _build_unparse_stack(unparse_stack, prepend_middleware):
         library = middleware.transform(library=library)
 
-    return write_string(library, bibtex_format=bibtex_format)
+    return write(library, bibtex_format=bibtex_format)

--- a/bibtexparser/writer.py
+++ b/bibtexparser/writer.py
@@ -81,7 +81,7 @@ def _calculate_auto_value_align(library: Library) -> int:
     return max_key_len + len(VAL_SEP)
 
 
-def write_string(
+def write(
     library: Library, bibtex_format: Optional["BibtexFormat"] = None
 ) -> str:
     """Serialize a BibTeX database to a string.


### PR DESCRIPTION
The `write_string` name is used twice in entrypoint,py and writer,py