### PR TITLE
:bug: Don't override original block when detecting duplicate

### DIFF
--- a/bibtexparser/library.py
+++ b/bibtexparser/library.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Union
 
 from .model import (
     Block,
-    DuplicateEntryKeyBlock,
+    DuplicateBlockKeyBlock,
     Entry,
     ExplicitComment,
     ImplicitComment,
@@ -37,9 +37,8 @@ class Library:
             blocks = [blocks]
 
         for block in blocks:
-            block = self._add_to_dicts(
-                block
-            )  # This may replace block with a DuplicateEntryKeyBlock
+            # This may replace block with a DuplicateEntryKeyBlock
+            block = self._add_to_dicts(block)
             self._blocks.append(block)
 
     def remove(self, blocks: Union[List[Block], Block]):
@@ -79,7 +78,7 @@ class Library:
 
         if (
             new_block is not block_after_add
-            and isinstance(new_block, DuplicateEntryKeyBlock)
+            and isinstance(new_block, DuplicateBlockKeyBlock)
             and fail_on_duplicate_key
         ):
             # Revert changes to old_block
@@ -106,7 +105,7 @@ class Library:
             prev_block_with_same_key.key == duplicate.key
         ), "Internal BibtexParser Error. Duplicate blocks have different keys."
 
-        return DuplicateEntryKeyBlock(
+        return DuplicateBlockKeyBlock(
             start_line=duplicate.start_line,
             raw=duplicate.raw,
             key=duplicate.key,

--- a/bibtexparser/library.py
+++ b/bibtexparser/library.py
@@ -37,7 +37,9 @@ class Library:
             blocks = [blocks]
 
         for block in blocks:
-            block = self._add_to_dicts(block) # This may replace block with a DuplicateEntryKeyBlock
+            block = self._add_to_dicts(
+                block
+            )  # This may replace block with a DuplicateEntryKeyBlock
             self._blocks.append(block)
 
     def remove(self, blocks: Union[List[Block], Block]):

--- a/bibtexparser/library.py
+++ b/bibtexparser/library.py
@@ -37,7 +37,7 @@ class Library:
             blocks = [blocks]
 
         for block in blocks:
-            block = self._add_to_dicts(block)
+            block = self._add_to_dicts(block) # This may replace block with a DuplicateEntryKeyBlock
             self._blocks.append(block)
 
     def remove(self, blocks: Union[List[Block], Block]):
@@ -116,25 +116,23 @@ class Library:
         """Safely add block references to private dict structures.
 
         :param block: Block to add.
-        :returns: The block that was added to the library, except if a block
-            of same type and with same key already exists, in which case a
-            DuplicateKeyBlock is returned.
+        :returns: The block that was added to the library. If a block
+            of same type and with same key already existed, a
+            DuplicateKeyBlock is returned (not added to dict).
         """
         if isinstance(block, Entry):
             try:
                 prev_block_with_same_key = self._entries_by_key[block.key]
                 block = self._cast_to_duplicate(prev_block_with_same_key, block)
             except KeyError:
-                pass  # No previous entry with same key
-            finally:
+                # No duplicate found
                 self._entries_by_key[block.key] = block
         elif isinstance(block, String):
             try:
                 prev_block_with_same_key = self._strings_by_key[block.key]
                 block = self._cast_to_duplicate(prev_block_with_same_key, block)
             except KeyError:
-                pass  # No previous string with same key
-            finally:
+                # No duplicate found
                 self._strings_by_key[block.key] = block
         return block
 

--- a/bibtexparser/model.py
+++ b/bibtexparser/model.py
@@ -386,7 +386,7 @@ class MiddlewareErrorBlock(ParsingFailedBlock):
         )
 
 
-class DuplicateEntryKeyBlock(ParsingFailedBlock):
+class DuplicateBlockKeyBlock(ParsingFailedBlock):
     """An error-indicating block created for blocks with keys present in the library already.
 
     To get the block that caused this error, call `block.ignore_error_block`."""

--- a/tests/middleware_tests/test_interpolate.py
+++ b/tests/middleware_tests/test_interpolate.py
@@ -58,15 +58,15 @@ def test_handles_duplicates():
     """Test case of #378, which failed in interpolation middleware"""
     import bibtexparser
     bibtex = """@article{duplicate,
-      author = {Duplicate, A.},
-      title = {Duplicate article},
-      year = {2022},
-    }
-    @article{duplicate,
-      author = {Duplicate, A.},
-      title = {Duplicate article},
-      year = {2022},
-    }"""
+  author = {Duplicate, A.},
+  title = {Duplicate article},
+  year = {2022},
+}
+@article{duplicate,
+  author = {Duplicate, A.},
+  title = {Duplicate article},
+  year = {2022},
+}"""
 
     lib = bibtexparser.parse_string(bibtex)
     return lib

--- a/tests/middleware_tests/test_interpolate.py
+++ b/tests/middleware_tests/test_interpolate.py
@@ -52,21 +52,3 @@ def test_warning_is_raised_if_enclosings_are_removed():
 
     assert len(record) == 1
     assert "RemoveEnclosing" in record[0].message.args[0]
-
-
-def test_handles_duplicates():
-    """Test case of #378, which failed in interpolation middleware"""
-    import bibtexparser
-    bibtex = """@article{duplicate,
-  author = {Duplicate, A.},
-  title = {Duplicate article},
-  year = {2022},
-}
-@article{duplicate,
-  author = {Duplicate, A.},
-  title = {Duplicate article},
-  year = {2022},
-}"""
-
-    lib = bibtexparser.parse_string(bibtex)
-    return lib

--- a/tests/middleware_tests/test_interpolate.py
+++ b/tests/middleware_tests/test_interpolate.py
@@ -52,3 +52,21 @@ def test_warning_is_raised_if_enclosings_are_removed():
 
     assert len(record) == 1
     assert "RemoveEnclosing" in record[0].message.args[0]
+
+
+def test_handles_duplicates():
+    """Test case of #378, which failed in interpolation middleware"""
+    import bibtexparser
+    bibtex = """@article{duplicate,
+      author = {Duplicate, A.},
+      title = {Duplicate article},
+      year = {2022},
+    }
+    @article{duplicate,
+      author = {Duplicate, A.},
+      title = {Duplicate article},
+      year = {2022},
+    }"""
+
+    lib = bibtexparser.parse_string(bibtex)
+    return lib

--- a/tests/splitter_tests/test_splitter_basic.py
+++ b/tests/splitter_tests/test_splitter_basic.py
@@ -263,3 +263,32 @@ def test_failed_block():
         'Was still looking for field-value closing `"`'
         in failed_block.error.abort_reason
     )
+
+
+duplicate_bibtex_entry_keys = """
+@article{duplicate,
+  author = {Duplicate, A.},
+  title = {Duplicate article 1},
+  year = {2021},
+}
+@article{duplicate,
+  author = {Duplicate, B.},
+  title = {Duplicate article 2},
+  year = {2022},
+}"""
+
+
+def test_handles_duplicates():
+    """Makes sure that duplicate keys are handled correctly."""
+    import bibtexparser
+
+    lib = bibtexparser.parse_string(duplicate_bibtex_entry_keys)
+    assert len(lib.blocks) == 2
+    assert len(lib.entries) == 1
+    assert len(lib.entries_dict) == 1
+    assert len(lib.failed_blocks) == 1
+
+    assert lib.entries[0]["title"] == "Duplicate article 1"
+    assert isinstance(lib.failed_blocks[0], bibtexparser.model.DuplicateEntryKeyBlock)
+    assert lib.failed_blocks[0].previous_block["title"] == "Duplicate article 1"
+    assert lib.failed_blocks[0].ignore_error_block["title"] == "{Duplicate article 2}"

--- a/tests/splitter_tests/test_splitter_basic.py
+++ b/tests/splitter_tests/test_splitter_basic.py
@@ -278,7 +278,7 @@ duplicate_bibtex_entry_keys = """
 }"""
 
 
-def test_handles_duplicates():
+def test_handles_duplicate_entries():
     """Makes sure that duplicate keys are handled correctly."""
     import bibtexparser
 
@@ -289,6 +289,33 @@ def test_handles_duplicates():
     assert len(lib.failed_blocks) == 1
 
     assert lib.entries[0]["title"] == "Duplicate article 1"
-    assert isinstance(lib.failed_blocks[0], bibtexparser.model.DuplicateEntryKeyBlock)
+    assert isinstance(lib.failed_blocks[0], bibtexparser.model.DuplicateBlockKeyBlock)
     assert lib.failed_blocks[0].previous_block["title"] == "Duplicate article 1"
     assert lib.failed_blocks[0].ignore_error_block["title"] == "{Duplicate article 2}"
+    assert isinstance(lib.failed_blocks[0].ignore_error_block, bibtexparser.model.Entry)
+
+
+duplicate_bibtex_string_keys = """
+@string{duplicate = "Duplicate string 1"}
+@string{duplicate = "Duplicate string 2"}
+@string{duplicate = "Duplicate string 3"}
+"""
+
+
+def test_handles_duplicate_strings():
+    """Makes sure that duplicate string keys are handled correctly."""
+    import bibtexparser
+
+    lib = bibtexparser.parse_string(duplicate_bibtex_string_keys)
+    assert len(lib.blocks) == 3
+    assert len(lib.strings) == 1
+    assert len(lib.strings_dict) == 1
+    assert len(lib.failed_blocks) == 2
+
+    assert lib.strings[0].value == "Duplicate string 1"
+    assert isinstance(lib.failed_blocks[0], bibtexparser.model.DuplicateBlockKeyBlock)
+    assert lib.failed_blocks[0].previous_block.value == "Duplicate string 1"
+    assert lib.failed_blocks[0].ignore_error_block.value == '"Duplicate string 2"'
+    assert isinstance(
+        lib.failed_blocks[0].ignore_error_block, bibtexparser.model.String
+    )


### PR DESCRIPTION
Besides fixing duplicate block key logic (making sure that the original and duplicate are in the library), this refactors the name of the DuplicateEntryKeyBlock to DuplicateBlockKeyBlock to reflect the fact that this class is also used by @string duplicates.

Closes #378