### PR TITLE
:bug: Error handling in name transformer middleware

### DIFF
--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -54,7 +54,7 @@ class _NameTransformerMiddleware(BlockMiddleware, abc.ABC):
                 if field.key in self.name_fields:
                     field.value = self._transform_field_value(field.value)
             return entry
-        except ValueError as e:
+        except InvalidNameError as e:
             return MiddlewareErrorBlock(
                 entry, e
             )

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -7,7 +7,7 @@ import abc
 import dataclasses
 from typing import List, Tuple
 
-from bibtexparser.model import Block, Entry, Field
+from bibtexparser.model import Block, Entry, Field, MiddlewareErrorBlock
 
 from .middleware import BlockMiddleware
 
@@ -49,11 +49,15 @@ class _NameTransformerMiddleware(BlockMiddleware, abc.ABC):
     # docstr-coverage: inherited
     def transform_entry(self, entry: Entry, *args, **kwargs) -> Block:
         field: Field
-        # TODO wrap in try/except to catch exceptions and create failed block if needed
-        for field in entry.fields:
-            if field.key in self.name_fields:
-                field.value = self._transform_field_value(field.value)
-        return entry
+        try:
+            for field in entry.fields:
+                if field.key in self.name_fields:
+                    field.value = self._transform_field_value(field.value)
+            return entry
+        except ValueError as e:
+            return MiddlewareErrorBlock(
+                entry, e
+            )
 
 
 class SeparateCoAuthors(_NameTransformerMiddleware):

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -55,9 +55,7 @@ class _NameTransformerMiddleware(BlockMiddleware, abc.ABC):
                     field.value = self._transform_field_value(field.value)
             return entry
         except InvalidNameError as e:
-            return MiddlewareErrorBlock(
-                entry, e
-            )
+            return MiddlewareErrorBlock(entry, e)
 
 
 class SeparateCoAuthors(_NameTransformerMiddleware):


### PR DESCRIPTION
Exceptions thrown in name-parsing middlewares are not caught, as noted here:
https://github.com/sciunto-org/python-bibtexparser/blob/9f32043364ead8b7c5c3b6bcc5e3b522d4a7e097/bibtexparser/middlewares/names.py#L52-L56

This PR catches `InvalidNameError`s thrown in name-parsing middlewares and wraps them in a `MiddlewareErrorBlock`.

It also introduces a test using the same conditions as here:
https://github.com/sciunto-org/python-bibtexparser/blob/9f32043364ead8b7c5c3b6bcc5e3b522d4a7e097/tests/middleware_tests/test_names.py#L99-L115