### PR TITLE
:bug:  Handle `None` and Collections in BlockMiddleware.transformBlock

### DIFF
--- a/bibtexparser/middlewares/middleware.py
+++ b/bibtexparser/middlewares/middleware.py
@@ -83,9 +83,16 @@ class BlockMiddleware(Middleware, abc.ABC):
             # Case 2: A single block. Add it to the list.
             elif isinstance(transformed, Block):
                 blocks.append(transformed)
-            # Case 3: Something else. Assume it's a collection and append them all.
-            else:
+            # Case 3: A collection. Append all the elements.
+            elif isinstance(transformed, Collection):
+                # check that all the items are indeed blocks
+                for item in transformed:
+                    if not isinstance(item, Block):
+                        raise TypeError(f"Non-Block type found in transformed collection: {type(item)}")
                 blocks.extend(transformed)
+            # Case 4: Something else. Error.
+            else:
+                raise TypeError(f"Illegal output type from transform_block: {type(transformed)}")
         return Library(blocks=blocks)
 
     def transform_block(

--- a/bibtexparser/middlewares/middleware.py
+++ b/bibtexparser/middlewares/middleware.py
@@ -77,10 +77,15 @@ class BlockMiddleware(Middleware, abc.ABC):
         blocks = []
         for b in library.blocks:
             transformed = self.transform_block(b, library)
+            # Case 1: None. Skip it.
             if transformed is None:
                 pass
-            else:
+            # Case 2: A single block. Add it to the list.
+            elif isinstance(transformed, Block):
                 blocks.append(transformed)
+            # Case 3: Something else. Assume it's a collection and append them all.
+            else:
+                blocks.extend(transformed)
         return Library(blocks=blocks)
 
     def transform_block(

--- a/bibtexparser/middlewares/middleware.py
+++ b/bibtexparser/middlewares/middleware.py
@@ -74,7 +74,13 @@ class BlockMiddleware(Middleware, abc.ABC):
     # docstr-coverage: inherited
     def transform(self, library: "Library") -> "Library":
         # TODO Multiprocessing (only for large library and if allow_multi..)
-        blocks = [self.transform_block(b, library) for b in library.blocks]
+        blocks = []
+        for b in library.blocks:
+            transformed = self.transform_block(b, library)
+            if transformed is None:
+                pass
+            else:
+                blocks.append(transformed)
         return Library(blocks=blocks)
 
     def transform_block(

--- a/bibtexparser/middlewares/middleware.py
+++ b/bibtexparser/middlewares/middleware.py
@@ -88,11 +88,15 @@ class BlockMiddleware(Middleware, abc.ABC):
                 # check that all the items are indeed blocks
                 for item in transformed:
                     if not isinstance(item, Block):
-                        raise TypeError(f"Non-Block type found in transformed collection: {type(item)}")
+                        raise TypeError(
+                            f"Non-Block type found in transformed collection: {type(item)}"
+                        )
                 blocks.extend(transformed)
             # Case 4: Something else. Error.
             else:
-                raise TypeError(f"Illegal output type from transform_block: {type(transformed)}")
+                raise TypeError(
+                    f"Illegal output type from transform_block: {type(transformed)}"
+                )
         return Library(blocks=blocks)
 
     def transform_block(

--- a/tests/middleware_tests/test_block_middleware.py
+++ b/tests/middleware_tests/test_block_middleware.py
@@ -34,53 +34,53 @@ def test_returning_none_removes_block():
     assert library.blocks == []
 
 def test_returning_list_adds_all():
-    class DoubleBlockMiddleware(BlockMiddleware):
-        """A middleware that duplicates every block."""
+    class PrefixBlockMiddleware(BlockMiddleware):
+        """A middleware that prefixes every block with a comment."""
         def __init__(self):
             super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
         def transform_block(self, block, library):
-            return [block, block]
+            return [ImplicitComment("% Block"), block]
         def metadata_key():
-            return "DoubleBlockMiddleware"
+            return "PrefixBlockMiddleware"
 
     library = Library(blocks=BLOCKS)
-    library = DoubleBlockMiddleware().transform(library)
+    library = PrefixBlockMiddleware().transform(library)
 
     expected = [
+        ImplicitComment("% Block"),
         ExplicitComment("explicit_comment_a"),
-        ExplicitComment("explicit_comment_a"),
 
+        ImplicitComment("% Block"),
         String("string_b", "value_b"),
-        String("string_b", "value_b"),
 
+        ImplicitComment("% Block"),
         String("string_a", "value_a"),
-        String("string_a", "value_a"),
 
+        ImplicitComment("% Block"),
         ImplicitComment("% implicit_comment_a"),
-        ImplicitComment("% implicit_comment_a"),
 
+        ImplicitComment("% Block"),
         ExplicitComment("explicit_comment_b"),
-        ExplicitComment("explicit_comment_b"),
 
+        ImplicitComment("% Block"),
         Entry("article", "entry_a", fields=[]),
-        Entry("article", "entry_a", fields=[]),
 
+        ImplicitComment("% Block"),
         ImplicitComment("% implicit_comment_b"),
-        ImplicitComment("% implicit_comment_b"),
 
+        ImplicitComment("% Block"),
         Entry("article", "entry_b", fields=[]),
-        Entry("article", "entry_b", fields=[]),
 
+        ImplicitComment("% Block"),
         Entry("article", "entry_d", fields=[]),
-        Entry("article", "entry_d", fields=[]),
 
+        ImplicitComment("% Block"),
         Entry("article", "entry_c", fields=[]),
-        Entry("article", "entry_c", fields=[]),
 
-        Preamble("preamble_a"),
+        ImplicitComment("% Block"),
         Preamble("preamble_a"),
 
-        ImplicitComment("% implicit_comment_c"),
+        ImplicitComment("% Block"),
         ImplicitComment("% implicit_comment_c"),
     ]
 

--- a/tests/middleware_tests/test_block_middleware.py
+++ b/tests/middleware_tests/test_block_middleware.py
@@ -18,7 +18,6 @@ BLOCKS = [
 ]
 
 def test_returning_none_removes_block():
-
     class AlwaysNoneBlockMiddleware(BlockMiddleware):
         """A middleware that returns None for every block."""
         def __init__(self):
@@ -32,6 +31,36 @@ def test_returning_none_removes_block():
     library = AlwaysNoneBlockMiddleware().transform(library)
 
     assert library.blocks == []
+
+def test_returning_empty_removes_block():
+    class AlwaysEmptyBlockMiddleware(BlockMiddleware):
+        """A middleware that returns an empty list for every block."""
+        def __init__(self):
+            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+        def transform_block(self, block, library):
+            return []
+        def metadata_key():
+            return "AlwaysEmptyBlockMiddleware"
+    
+    library = Library(blocks=BLOCKS)
+    library = AlwaysEmptyBlockMiddleware().transform(library)
+
+    assert library.blocks == []
+
+def test_returning_singleton_keeps_block():
+    class SingletonBlockMiddleware(BlockMiddleware):
+        """A middleware that returns a singleton list for every block."""
+        def __init__(self):
+            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+        def transform_block(self, block, library):
+            return [block]
+        def metadata_key():
+            return "SingletonBlockMiddleware"
+    
+    library = Library(blocks=BLOCKS)
+    library = SingletonBlockMiddleware().transform(library)
+
+    assert library.blocks == BLOCKS
 
 def test_returning_list_adds_all():
     class PrefixBlockMiddleware(BlockMiddleware):

--- a/tests/middleware_tests/test_block_middleware.py
+++ b/tests/middleware_tests/test_block_middleware.py
@@ -1,6 +1,6 @@
 from bibtexparser import Library
-from bibtexparser.model import Entry, ExplicitComment, ImplicitComment, Preamble, String
 from bibtexparser.middlewares.middleware import BlockMiddleware
+from bibtexparser.model import Entry, ExplicitComment, ImplicitComment, Preamble, String
 
 BLOCKS = [
     ExplicitComment("explicit_comment_a"),
@@ -17,58 +17,82 @@ BLOCKS = [
     ImplicitComment("% implicit_comment_c"),
 ]
 
+
 def test_returning_none_removes_block():
     class AlwaysNoneBlockMiddleware(BlockMiddleware):
         """A middleware that returns None for every block."""
+
         def __init__(self):
-            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+            super().__init__(
+                allow_parallel_execution=True, allow_inplace_modification=True
+            )
+
         def transform_block(self, block, library):
             return None
+
         def metadata_key():
             return "AlwaysNoneBlockMiddleware"
-    
+
     library = Library(blocks=BLOCKS)
     library = AlwaysNoneBlockMiddleware().transform(library)
 
     assert library.blocks == []
 
+
 def test_returning_empty_removes_block():
     class AlwaysEmptyBlockMiddleware(BlockMiddleware):
         """A middleware that returns an empty list for every block."""
+
         def __init__(self):
-            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+            super().__init__(
+                allow_parallel_execution=True, allow_inplace_modification=True
+            )
+
         def transform_block(self, block, library):
             return []
+
         def metadata_key():
             return "AlwaysEmptyBlockMiddleware"
-    
+
     library = Library(blocks=BLOCKS)
     library = AlwaysEmptyBlockMiddleware().transform(library)
 
     assert library.blocks == []
 
+
 def test_returning_singleton_keeps_block():
     class SingletonBlockMiddleware(BlockMiddleware):
         """A middleware that returns a singleton list for every block."""
+
         def __init__(self):
-            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+            super().__init__(
+                allow_parallel_execution=True, allow_inplace_modification=True
+            )
+
         def transform_block(self, block, library):
             return [block]
+
         def metadata_key():
             return "SingletonBlockMiddleware"
-    
+
     library = Library(blocks=BLOCKS)
     library = SingletonBlockMiddleware().transform(library)
 
     assert library.blocks == BLOCKS
 
+
 def test_returning_list_adds_all():
     class PrefixBlockMiddleware(BlockMiddleware):
         """A middleware that prefixes every block with a comment."""
+
         def __init__(self):
-            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+            super().__init__(
+                allow_parallel_execution=True, allow_inplace_modification=True
+            )
+
         def transform_block(self, block, library):
             return [ImplicitComment("% Block"), block]
+
         def metadata_key():
             return "PrefixBlockMiddleware"
 
@@ -78,37 +102,26 @@ def test_returning_list_adds_all():
     expected = [
         ImplicitComment("% Block"),
         ExplicitComment("explicit_comment_a"),
-
         ImplicitComment("% Block"),
         String("string_b", "value_b"),
-
         ImplicitComment("% Block"),
         String("string_a", "value_a"),
-
         ImplicitComment("% Block"),
         ImplicitComment("% implicit_comment_a"),
-
         ImplicitComment("% Block"),
         ExplicitComment("explicit_comment_b"),
-
         ImplicitComment("% Block"),
         Entry("article", "entry_a", fields=[]),
-
         ImplicitComment("% Block"),
         ImplicitComment("% implicit_comment_b"),
-
         ImplicitComment("% Block"),
         Entry("article", "entry_b", fields=[]),
-
         ImplicitComment("% Block"),
         Entry("article", "entry_d", fields=[]),
-
         ImplicitComment("% Block"),
         Entry("article", "entry_c", fields=[]),
-
         ImplicitComment("% Block"),
         Preamble("preamble_a"),
-
         ImplicitComment("% Block"),
         ImplicitComment("% implicit_comment_c"),
     ]

--- a/tests/middleware_tests/test_block_middleware.py
+++ b/tests/middleware_tests/test_block_middleware.py
@@ -1,0 +1,35 @@
+from bibtexparser import Library
+from bibtexparser.model import Entry, ExplicitComment, ImplicitComment, Preamble, String
+from bibtexparser.middlewares.middleware import BlockMiddleware
+
+BLOCKS = [
+    ExplicitComment("explicit_comment_a"),
+    String("string_b", "value_b"),
+    String("string_a", "value_a"),
+    ImplicitComment("% implicit_comment_a"),
+    ExplicitComment("explicit_comment_b"),
+    Entry("article", "entry_a", fields=[]),
+    ImplicitComment("% implicit_comment_b"),
+    Entry("article", "entry_b", fields=[]),
+    Entry("article", "entry_d", fields=[]),
+    Entry("article", "entry_c", fields=[]),
+    Preamble("preamble_a"),
+    ImplicitComment("% implicit_comment_c"),
+]
+
+def test_returning_none_removes_block():
+
+    class AlwaysNoneBlockMiddleware(BlockMiddleware):
+        """A middleware that returns None for every block."""
+        def __init__(self):
+            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+        def transform_block(self, block, library):
+            return None
+        def metadata_key():
+            return "AlwaysNoneBlockMiddleware"
+    
+    library = Library(blocks=BLOCKS)
+    library = AlwaysNoneBlockMiddleware().transform(library)
+
+    assert library.blocks == []
+

--- a/tests/middleware_tests/test_block_middleware.py
+++ b/tests/middleware_tests/test_block_middleware.py
@@ -19,14 +19,13 @@ BLOCKS = [
     ImplicitComment("% implicit_comment_c"),
 ]
 
+
 class ConstantBlockMiddleware(BlockMiddleware):
     """A middleware that always returns the same result for every block."""
 
     def __init__(self, const):
         self._const = const
-        super().__init__(
-            allow_parallel_execution=True, allow_inplace_modification=True
-        )
+        super().__init__(allow_parallel_execution=True, allow_inplace_modification=True)
 
     def transform_block(self, block, library):
         return self._const
@@ -34,13 +33,13 @@ class ConstantBlockMiddleware(BlockMiddleware):
     def metadata_key():
         return "ConstantBlockMiddleware"
 
+
 class LambdaBlockMiddleware(BlockMiddleware):
     """A middleware that applies a lambda to the input block"""
+
     def __init__(self, f):
         self._f = f
-        super().__init__(
-            allow_parallel_execution=True, allow_inplace_modification=True
-        )
+        super().__init__(allow_parallel_execution=True, allow_inplace_modification=True)
 
     def transform_block(self, block, library):
         return self._f(block)
@@ -48,20 +47,27 @@ class LambdaBlockMiddleware(BlockMiddleware):
     def metadata_key():
         return "LambdaBlockMiddleware"
 
-@pytest.mark.parametrize(("middleware", "expected"), [
-    (ConstantBlockMiddleware(None), []),
-    (ConstantBlockMiddleware([]), []),
-    (LambdaBlockMiddleware(lambda b: [b]), BLOCKS),
-])
+
+@pytest.mark.parametrize(
+    ("middleware", "expected"),
+    [
+        (ConstantBlockMiddleware(None), []),
+        (ConstantBlockMiddleware([]), []),
+        (LambdaBlockMiddleware(lambda b: [b]), BLOCKS),
+    ],
+)
 def test_successful_transform(middleware, expected):
     library = Library(blocks=BLOCKS)
     library = middleware.transform(library)
 
     assert library.blocks == expected
 
+
 def test_returning_list_adds_all():
     library = Library(blocks=BLOCKS)
-    library = LambdaBlockMiddleware(lambda b: [ImplicitComment("% Block"), b]).transform(library)
+    library = LambdaBlockMiddleware(
+        lambda b: [ImplicitComment("% Block"), b]
+    ).transform(library)
 
     expected = [
         ImplicitComment("% Block"),
@@ -92,11 +98,17 @@ def test_returning_list_adds_all():
 
     assert library.blocks == expected
 
-@pytest.mark.parametrize("middleware", [
-    ConstantBlockMiddleware(True),
-    ConstantBlockMiddleware([True]),
-    LambdaBlockMiddleware(lambda block: (b for b in [block])), # generators are not collections
-])
+
+@pytest.mark.parametrize(
+    "middleware",
+    [
+        ConstantBlockMiddleware(True),
+        ConstantBlockMiddleware([True]),
+        LambdaBlockMiddleware(
+            lambda block: (b for b in [block])
+        ),  # generators are not collections
+    ],
+)
 def test_returning_invalid_raises_error(middleware):
     library = Library(blocks=BLOCKS)
     with pytest.raises(TypeError):

--- a/tests/middleware_tests/test_block_middleware.py
+++ b/tests/middleware_tests/test_block_middleware.py
@@ -33,3 +33,55 @@ def test_returning_none_removes_block():
 
     assert library.blocks == []
 
+def test_returning_list_adds_all():
+    class DoubleBlockMiddleware(BlockMiddleware):
+        """A middleware that duplicates every block."""
+        def __init__(self):
+            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+        def transform_block(self, block, library):
+            return [block, block]
+        def metadata_key():
+            return "DoubleBlockMiddleware"
+
+    library = Library(blocks=BLOCKS)
+    library = DoubleBlockMiddleware().transform(library)
+
+    expected = [
+        ExplicitComment("explicit_comment_a"),
+        ExplicitComment("explicit_comment_a"),
+
+        String("string_b", "value_b"),
+        String("string_b", "value_b"),
+
+        String("string_a", "value_a"),
+        String("string_a", "value_a"),
+
+        ImplicitComment("% implicit_comment_a"),
+        ImplicitComment("% implicit_comment_a"),
+
+        ExplicitComment("explicit_comment_b"),
+        ExplicitComment("explicit_comment_b"),
+
+        Entry("article", "entry_a", fields=[]),
+        Entry("article", "entry_a", fields=[]),
+
+        ImplicitComment("% implicit_comment_b"),
+        ImplicitComment("% implicit_comment_b"),
+
+        Entry("article", "entry_b", fields=[]),
+        Entry("article", "entry_b", fields=[]),
+
+        Entry("article", "entry_d", fields=[]),
+        Entry("article", "entry_d", fields=[]),
+
+        Entry("article", "entry_c", fields=[]),
+        Entry("article", "entry_c", fields=[]),
+
+        Preamble("preamble_a"),
+        Preamble("preamble_a"),
+
+        ImplicitComment("% implicit_comment_c"),
+        ImplicitComment("% implicit_comment_c"),
+    ]
+
+    assert library.blocks == expected

--- a/tests/middleware_tests/test_block_middleware.py
+++ b/tests/middleware_tests/test_block_middleware.py
@@ -130,45 +130,62 @@ def test_returning_list_adds_all():
 
     assert library.blocks == expected
 
+
 def test_returning_bool_raises_error():
     class AlwaysTrueBlockMiddleware(BlockMiddleware):
         """A middleware that returns True for every block."""
+
         def __init__(self):
-            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+            super().__init__(
+                allow_parallel_execution=True, allow_inplace_modification=True
+            )
+
         def transform_block(self, block, library):
             return True
+
         def metadata_key():
             return "AlwaysTrueBlockMiddleware"
-    
+
     library = Library(blocks=BLOCKS)
     with pytest.raises(TypeError):
         library = AlwaysTrueBlockMiddleware().transform(library)
 
+
 def test_returning_bool_list_raises_error():
     class AlwaysTrueListBlockMiddleware(BlockMiddleware):
         """A middleware that returns [True] for every block."""
+
         def __init__(self):
-            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+            super().__init__(
+                allow_parallel_execution=True, allow_inplace_modification=True
+            )
+
         def transform_block(self, block, library):
             return [True]
+
         def metadata_key():
             return "AlwaysTrueListBlockMiddleware"
-    
+
     library = Library(blocks=BLOCKS)
     with pytest.raises(TypeError):
         library = AlwaysTrueListBlockMiddleware().transform(library)
 
+
 def test_returning_generator_raises_error():
     class SingletonGeneratorBlockMiddleware(BlockMiddleware):
         """A middleware that returns a generator for every block."""
+
         def __init__(self):
-            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+            super().__init__(
+                allow_parallel_execution=True, allow_inplace_modification=True
+            )
+
         def transform_block(self, block, library):
             return (b for b in [block])
+
         def metadata_key():
             return "SingletonGeneratorBlockMiddleware"
-    
+
     library = Library(blocks=BLOCKS)
     with pytest.raises(TypeError):
         library = SingletonGeneratorBlockMiddleware().transform(library)
-

--- a/tests/middleware_tests/test_block_middleware.py
+++ b/tests/middleware_tests/test_block_middleware.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bibtexparser import Library
 from bibtexparser.middlewares.middleware import BlockMiddleware
 from bibtexparser.model import Entry, ExplicitComment, ImplicitComment, Preamble, String
@@ -127,3 +129,46 @@ def test_returning_list_adds_all():
     ]
 
     assert library.blocks == expected
+
+def test_returning_bool_raises_error():
+    class AlwaysTrueBlockMiddleware(BlockMiddleware):
+        """A middleware that returns True for every block."""
+        def __init__(self):
+            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+        def transform_block(self, block, library):
+            return True
+        def metadata_key():
+            return "AlwaysTrueBlockMiddleware"
+    
+    library = Library(blocks=BLOCKS)
+    with pytest.raises(TypeError):
+        library = AlwaysTrueBlockMiddleware().transform(library)
+
+def test_returning_bool_list_raises_error():
+    class AlwaysTrueListBlockMiddleware(BlockMiddleware):
+        """A middleware that returns [True] for every block."""
+        def __init__(self):
+            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+        def transform_block(self, block, library):
+            return [True]
+        def metadata_key():
+            return "AlwaysTrueListBlockMiddleware"
+    
+    library = Library(blocks=BLOCKS)
+    with pytest.raises(TypeError):
+        library = AlwaysTrueListBlockMiddleware().transform(library)
+
+def test_returning_generator_raises_error():
+    class SingletonGeneratorBlockMiddleware(BlockMiddleware):
+        """A middleware that returns a generator for every block."""
+        def __init__(self):
+            super().__init__(allow_parallel_execution = True, allow_inplace_modification = True)
+        def transform_block(self, block, library):
+            return (b for b in [block])
+        def metadata_key():
+            return "SingletonGeneratorBlockMiddleware"
+    
+    library = Library(blocks=BLOCKS)
+    with pytest.raises(TypeError):
+        library = SingletonGeneratorBlockMiddleware().transform(library)
+


### PR DESCRIPTION
This fixes #386.

For the tests I stole the sample blocks from `test_sorting_blocks.py`.