### PR TITLE
:bug: Allow trailing whitespaces for entry types, before `{`

### DIFF
--- a/bibtexparser/splitter.py
+++ b/bibtexparser/splitter.py
@@ -231,7 +231,7 @@ class Splitter:
             The library with the added blocks.
         """
         self._markiter = re.finditer(
-            r"(?<!\\)[\{\}\",=\n]|(?<=\n)@[\w]*(?={)", self.bibstr, re.MULTILINE
+            r"(?<!\\)[\{\}\",=\n]|(?<=\n)@[\w]*( |\t)*(?={)", self.bibstr, re.MULTILINE
         )
 
         if library is None:
@@ -337,7 +337,7 @@ class Splitter:
     def _handle_entry(self, m, m_val) -> Union[Entry, ParsingFailedBlock]:
         """Handle entry block. Return end index"""
         start_line = self._current_line
-        entry_type = m_val[1:]
+        entry_type = m_val[1:].strip()
         start_bracket_mark = self._next_mark(accept_eof=False)
         if start_bracket_mark.group(0) != "{":
             self._unaccepted_mark = start_bracket_mark

--- a/dev-utilities/bibtex-nameparsing/parsename.py
+++ b/dev-utilities/bibtex-nameparsing/parsename.py
@@ -12,11 +12,14 @@ try:
     from tempfile import TemporaryDirectory
 except ImportError:
     from tempfile import mkdtemp
+
     class TemporaryDirectory(object):
         def __init__(self):
             self.name = mkdtemp()
+
         def __enter__(self):
             return self.name
+
         def __exit__(self, exc, value, tb):
             shutil.rmtree(self.name)
 
@@ -42,12 +45,16 @@ def evaluate_bibtex_parsename(tempdir, names):
     # Write entries for each string in the list.
     with open(os.path.join(tempdir, "parsename.bib"), "w") as bibfile:
         for i, name in enumerate(names):
-            bibfile.write('@parsename{{case{0:d}, author={{{1:s}}}}}\n'.format(i, name))
+            bibfile.write("@parsename{{case{0:d}, author={{{1:s}}}}}\n".format(i, name))
 
     # Run BibTeX.
-    proc = subprocess.Popen(["bibtex", "parsename"], cwd=tempdir,
-                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                            universal_newlines=True)
+    proc = subprocess.Popen(
+        ["bibtex", "parsename"],
+        cwd=tempdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
     proc.wait()
 
     # Error.

--- a/dev-utilities/bibtex-nameparsing/splitnames.py
+++ b/dev-utilities/bibtex-nameparsing/splitnames.py
@@ -12,11 +12,14 @@ try:
     from tempfile import TemporaryDirectory
 except ImportError:
     from tempfile import mkdtemp
+
     class TemporaryDirectory(object):
         def __init__(self):
             self.name = mkdtemp()
+
         def __enter__(self):
             return self.name
+
         def __exit__(self, exc, value, tb):
             shutil.rmtree(self.name)
 
@@ -42,12 +45,18 @@ def evaluate_bibtex_splitnames(tempdir, names):
     # Write entries for each string in the list.
     with open(os.path.join(tempdir, "splitnames.bib"), "w") as bibfile:
         for i, name in enumerate(names):
-            bibfile.write('@splitnames{{case{0:d}, author={{{1:s}}}}}\n'.format(i, name))
+            bibfile.write(
+                "@splitnames{{case{0:d}, author={{{1:s}}}}}\n".format(i, name)
+            )
 
     # Run BibTeX.
-    proc = subprocess.Popen(["bibtex", "splitnames"], cwd=tempdir,
-                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                            universal_newlines=True)
+    proc = subprocess.Popen(
+        ["bibtex", "splitnames"],
+        cwd=tempdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
     proc.wait()
 
     # Error.

--- a/tests/splitter_tests/test_splitter_entry.py
+++ b/tests/splitter_tests/test_splitter_entry.py
@@ -219,7 +219,8 @@ def test_entry_with_space_before_bracket(entry: str):
     assert len(library.failed_blocks) == 0
 
     assert library.entries[0].key == "normal_entry"
-    assert len(library.entries[0].fields) == 1
+    assert len(library.entries[0].fields) == 2
 
+    assert library.entries[1].entry_type == "article"
     assert library.entries[1].key == "articleTestKey"
     assert len(library.entries[1].fields) == 1

--- a/tests/splitter_tests/test_splitter_entry.py
+++ b/tests/splitter_tests/test_splitter_entry.py
@@ -124,8 +124,8 @@ def test_trailing_comma(enclosing: str):
     assert len(library.entries[0].fields) == 2
     assert library.entries[0].fields_dict["firstfield"].value == "{some value}"
     assert (
-        library.entries[0].fields_dict["fieldBeforeTrailingComma"].value
-        == value_before_trailing_comma
+            library.entries[0].fields_dict["fieldBeforeTrailingComma"].value
+            == value_before_trailing_comma
     )
 
     # Make sure that subsequent blocks are still parsed correctly
@@ -195,4 +195,31 @@ def test_entry_without_fields(entry_without_fields: str):
     assert len(library.entries[0].fields) == 0
 
     assert library.entries[1].key == "subsequentArticle"
+    assert len(library.entries[1].fields) == 1
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        # common in revtex, see issue #384
+        pytest.param("@Article {articleTestKey, title = {Some title}}", id="single whitespace"),
+        pytest.param("@Article  {articleTestKey, title = {Some title}}", id="double whitespace"),
+        pytest.param("@Article\t{articleTestKey, title = {Some title}}", id="tab"),
+        pytest.param("@Article \t {articleTestKey, title = {Some title}}", id="tab and whitespaces"),
+    ],
+)
+def test_entry_with_space_before_bracket(entry: str):
+    """For motivation why we need this, please see issue #391"""
+    some_previous_entry = "@article{normal_entry, title = {The first title}, author = {The first author} }"
+
+    full_bibtex = f"{some_previous_entry}\n\n{entry}\n\n"
+    library: Library = Splitter(full_bibtex).split()
+    assert len(library.blocks) == 2
+    assert len(library.entries) == 2
+    assert len(library.failed_blocks) == 0
+
+    assert library.entries[0].key == "normal_entry"
+    assert len(library.entries[0].fields) == 1
+
+    assert library.entries[1].key == "articleTestKey"
     assert len(library.entries[1].fields) == 1

--- a/tests/splitter_tests/test_splitter_entry.py
+++ b/tests/splitter_tests/test_splitter_entry.py
@@ -124,8 +124,8 @@ def test_trailing_comma(enclosing: str):
     assert len(library.entries[0].fields) == 2
     assert library.entries[0].fields_dict["firstfield"].value == "{some value}"
     assert (
-            library.entries[0].fields_dict["fieldBeforeTrailingComma"].value
-            == value_before_trailing_comma
+        library.entries[0].fields_dict["fieldBeforeTrailingComma"].value
+        == value_before_trailing_comma
     )
 
     # Make sure that subsequent blocks are still parsed correctly
@@ -202,10 +202,17 @@ def test_entry_without_fields(entry_without_fields: str):
     "entry",
     [
         # common in revtex, see issue #384
-        pytest.param("@Article {articleTestKey, title = {Some title}}", id="single whitespace"),
-        pytest.param("@Article  {articleTestKey, title = {Some title}}", id="double whitespace"),
+        pytest.param(
+            "@Article {articleTestKey, title = {Some title}}", id="single whitespace"
+        ),
+        pytest.param(
+            "@Article  {articleTestKey, title = {Some title}}", id="double whitespace"
+        ),
         pytest.param("@Article\t{articleTestKey, title = {Some title}}", id="tab"),
-        pytest.param("@Article \t {articleTestKey, title = {Some title}}", id="tab and whitespaces"),
+        pytest.param(
+            "@Article \t {articleTestKey, title = {Some title}}",
+            id="tab and whitespaces",
+        ),
     ],
 )
 def test_entry_with_space_before_bracket(entry: str):


### PR DESCRIPTION
Closes #391