### PR TITLE
:sparkles: handle concatenated fields with inner quotes in splitter

### DIFF
--- a/bibtexparser/splitter.py
+++ b/bibtexparser/splitter.py
@@ -59,7 +59,7 @@ class Splitter:
         if self._implicit_comment_start is None:
             return  # No implicit comment started
 
-        comment = self.bibstr[self._implicit_comment_start: end_char_index]
+        comment = self.bibstr[self._implicit_comment_start : end_char_index]
 
         # Clear leading and trailing empty lines,
         #   and count how many lines were removed, to adapt start_line below
@@ -124,18 +124,20 @@ class Splitter:
                 self._unaccepted_mark = m
                 raise BlockAbortedException(
                     abort_reason=f"Unexpected block start: `{m.group(0)}`. "
-                                 f"Was still looking for closing bracket",
+                    f"Was still looking for closing bracket",
                     end_index=m.start() - 1,
                 )
 
-    def _move_to_comma_or_closing_curly_bracket(self, currently_quote_escaped=False, num_open_curls=0) -> int:
+    def _move_to_comma_or_closing_curly_bracket(
+        self, currently_quote_escaped=False, num_open_curls=0
+    ) -> int:
         """Index of the end of the field, taking quote-escape into account."""
 
         if num_open_curls > 0 and currently_quote_escaped:
             raise ParserStateException(
                 message="Internal error in parser. "
-                        "Found a field-value that is both quote-escaped and curly-escaped. "
-                        "Please report this bug."
+                "Found a field-value that is both quote-escaped and curly-escaped. "
+                "Please report this bug."
             )
 
         def _is_escaped():
@@ -152,7 +154,11 @@ class Splitter:
             elif next_mark.group(0) == "{" and not currently_quote_escaped:
                 num_open_curls += 1
                 continue
-            elif next_mark.group(0) == "}" and not currently_quote_escaped and num_open_curls > 0:
+            elif (
+                next_mark.group(0) == "}"
+                and not currently_quote_escaped
+                and num_open_curls > 0
+            ):
                 num_open_curls -= 1
                 continue
 
@@ -172,18 +178,18 @@ class Splitter:
                 if currently_quote_escaped:
                     looking_for = '`"`'
                 elif num_open_curls > 0:
-                    looking_for = '`}`'
+                    looking_for = "`}`"
                 else:
-                    looking_for = '`,` or `}`'
+                    looking_for = "`,` or `}`"
 
                 raise BlockAbortedException(
                     abort_reason=f"Unexpected block start: `{next_mark.group(0)}`. "
-                                 f'Was still looking for field-value closing {looking_for} ',
+                    f"Was still looking for field-value closing {looking_for} ",
                     end_index=next_mark.start() - 1,
                 )
 
     def _move_to_end_of_entry(
-            self, first_key_start: int
+        self, first_key_start: int
     ) -> Tuple[List[Field], int, Set[str]]:
         """Move to the end of the entry and return the fields and the end index."""
         result = []
@@ -201,7 +207,7 @@ class Splitter:
                 self._unaccepted_mark = equals_mark
                 raise BlockAbortedException(
                     abort_reason="Expected a `=` after entry key, "
-                                 f"but found `{equals_mark.group(0)}`.",
+                    f"but found `{equals_mark.group(0)}`.",
                     end_index=equals_mark.start(),
                 )
 
@@ -210,7 +216,9 @@ class Splitter:
             start_line = self._current_line
             key_end = equals_mark.start()
             value_start = equals_mark.end()
-            value_end = self._move_to_comma_or_closing_curly_bracket(currently_quote_escaped=False, num_open_curls=0)
+            value_end = self._move_to_comma_or_closing_curly_bracket(
+                currently_quote_escaped=False, num_open_curls=0
+            )
 
             key = self.bibstr[key_start:key_end].strip()
             value = self.bibstr[value_start:value_end].strip()
@@ -233,7 +241,7 @@ class Splitter:
                 self._unaccepted_mark = after_field_mark
                 raise BlockAbortedException(
                     abort_reason="Expected either a `,` or `}` after a closed entry field value, "
-                                 f"but found a {after_field_mark.group(0)} before.",
+                    f"but found a {after_field_mark.group(0)} before.",
                     end_index=after_field_mark.start(),
                 )
 
@@ -292,7 +300,7 @@ class Splitter:
                     library.add(
                         ParsingFailedBlock(
                             start_line=start_line,
-                            raw=self.bibstr[m.start(): e.end_index],
+                            raw=self.bibstr[m.start() : e.end_index],
                             error=e,
                         )
                     )
@@ -342,11 +350,11 @@ class Splitter:
                 second_match=start_bracket_mark.group(0),
             )
         end_bracket_index = self._move_to_closed_bracket()
-        comment_str = self.bibstr[start_bracket_mark.end(): end_bracket_index].strip()
+        comment_str = self.bibstr[start_bracket_mark.end() : end_bracket_index].strip()
         return ExplicitComment(
             start_line=start_line,
             comment=comment_str,
-            raw=self.bibstr[start_index: end_bracket_index + 1],
+            raw=self.bibstr[start_index : end_bracket_index + 1],
         )
 
     def _handle_entry(self, m, m_val) -> Union[Entry, ParsingFailedBlock]:
@@ -359,25 +367,25 @@ class Splitter:
             # Note: The following should never happen, as we check for the "{" in the regex
             raise ParserStateException(
                 message="matched a regex that should end with `{`, "
-                        "e.g. `@article{`, "
-                        "but no closing bracket was found."
+                "e.g. `@article{`, "
+                "but no closing bracket was found."
             )
         comma_mark = self._next_mark(accept_eof=False)
         if comma_mark.group(0) == "}":
             # This is an entry without any comma after the key, and with no fields
             #   Used e.g. by RefTeX (see issue #384)
-            key = self.bibstr[m.end() + 1: comma_mark.start()].strip()
+            key = self.bibstr[m.end() + 1 : comma_mark.start()].strip()
             fields, end_index, duplicate_keys = [], comma_mark.end(), []
         elif comma_mark.group(0) != ",":
             self._unaccepted_mark = comma_mark
             raise BlockAbortedException(
                 abort_reason="Expected comma after entry key,"
-                             f" but found {comma_mark.group(0)}",
+                f" but found {comma_mark.group(0)}",
                 end_index=comma_mark.end(),
             )
         else:
             self._open_brackets += 1
-            key = self.bibstr[m.end() + 1: comma_mark.start()].strip()
+            key = self.bibstr[m.end() + 1 : comma_mark.start()].strip()
             fields, end_index, duplicate_keys = self._move_to_end_of_entry(
                 comma_mark.end()
             )
@@ -387,7 +395,7 @@ class Splitter:
             entry_type=entry_type,
             key=key,
             fields=fields,
-            raw=self.bibstr[m.start(): end_index + 1],
+            raw=self.bibstr[m.start() : end_index + 1],
         )
 
         # If there were duplicate field keys, we return a DuplicateFieldKeyBlock wrapping
@@ -407,17 +415,17 @@ class Splitter:
             # Note: The following should never happen, as we check for the "{" in the regex
             raise ParserStateException(
                 message="matched a string def regex (`@string{`) that "
-                        "should end with `{`, but no closing bracket was found."
+                "should end with `{`, but no closing bracket was found."
             )
         equals_mark = self._next_mark(accept_eof=False)
         if equals_mark.group(0) != "=":
             self._unaccepted_mark = equals_mark
             raise BlockAbortedException(
                 abort_reason="Expected equals sign after field key,"
-                             f" but found {equals_mark.group(0)}",
+                f" but found {equals_mark.group(0)}",
                 end_index=equals_mark.end(),
             )
-        key = self.bibstr[m.end() + 1: equals_mark.start()].strip()
+        key = self.bibstr[m.end() + 1 : equals_mark.start()].strip()
         value_start = equals_mark.end()
         end_i = self._move_to_closed_bracket()
         value = self.bibstr[value_start:end_i].strip()
@@ -425,7 +433,7 @@ class Splitter:
             start_line=start_line,
             key=key,
             value=value,
-            raw=self.bibstr[start_i: end_i + 1],
+            raw=self.bibstr[start_i : end_i + 1],
         )
 
     def _handle_preamble(self) -> Preamble:
@@ -438,13 +446,13 @@ class Splitter:
             # Note: The following should never happen, as we check for the "{" in the regex
             raise ParserStateException(
                 message="matched a preamble def regex (`@preamble{`) that "
-                        "should end with `{`, but no closing bracket was found."
+                "should end with `{`, but no closing bracket was found."
             )
 
         end_bracket_index = self._move_to_closed_bracket()
-        preamble = self.bibstr[start_bracket_mark.end(): end_bracket_index]
+        preamble = self.bibstr[start_bracket_mark.end() : end_bracket_index]
         return Preamble(
             start_line=start_line,
             value=preamble,
-            raw=self.bibstr[start_i: end_bracket_index + 1],
+            raw=self.bibstr[start_i : end_bracket_index + 1],
         )

--- a/tests/splitter_tests/test_splitter_entry.py
+++ b/tests/splitter_tests/test_splitter_entry.py
@@ -124,8 +124,8 @@ def test_trailing_comma(enclosing: str):
     assert len(library.entries[0].fields) == 2
     assert library.entries[0].fields_dict["firstfield"].value == "{some value}"
     assert (
-        library.entries[0].fields_dict["fieldBeforeTrailingComma"].value
-        == value_before_trailing_comma
+            library.entries[0].fields_dict["fieldBeforeTrailingComma"].value
+            == value_before_trailing_comma
     )
 
     # Make sure that subsequent blocks are still parsed correctly
@@ -196,6 +196,37 @@ def test_entry_without_fields(entry_without_fields: str):
 
     assert library.entries[1].key == "subsequentArticle"
     assert len(library.entries[1].fields) == 1
+
+
+@pytest.mark.parametrize(
+    "entry, expected",
+    [
+        # See issue #396
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan}', r'10 # "~" # jan', id="inner quotes"),
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan,}', r'10 # "~" # jan',
+                     id="inner quotes + comma"),
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan, author = "Paul"}', r'10 # "~" # jan',
+                     id="inner quotes + other field"),
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = "~" # jan}', r'"~" # jan',
+                     id=r'starting quotes'),
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = "~" # jan, }', r'"~" # jan',
+                     id=r'starting quotes + comma'),
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = "~" # jan, author = "Paul"}', r'"~" # jan',
+                     id="starting quotes + other field"),
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = jan # "~"}', r'jan # "~"',
+                     id=r'ending quotes'),
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = jan # "~",}', r'jan # "~"',
+                     id=r'ending quotes + comma'),
+        pytest.param(r'@INBOOK{inbook-full, relevant_field = jan # "~", author = "Paul"}', r'jan # "~"',
+                     id="ending quotes + other field"),
+    ],
+)
+def test_entry_with_concatenated_field(entry, expected):
+    """For motivation why we need this, please see issue #384"""
+    library: Library = Splitter(entry).split()
+    assert len(library.entries) == 1
+    assert len(library.failed_blocks) == 0
+    assert library.entries[0]["relevant_field"] == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/splitter_tests/test_splitter_entry.py
+++ b/tests/splitter_tests/test_splitter_entry.py
@@ -124,8 +124,8 @@ def test_trailing_comma(enclosing: str):
     assert len(library.entries[0].fields) == 2
     assert library.entries[0].fields_dict["firstfield"].value == "{some value}"
     assert (
-            library.entries[0].fields_dict["fieldBeforeTrailingComma"].value
-            == value_before_trailing_comma
+        library.entries[0].fields_dict["fieldBeforeTrailingComma"].value
+        == value_before_trailing_comma
     )
 
     # Make sure that subsequent blocks are still parsed correctly
@@ -202,23 +202,51 @@ def test_entry_without_fields(entry_without_fields: str):
     "entry, expected",
     [
         # See issue #396
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan}', r'10 # "~" # jan', id="inner quotes"),
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan,}', r'10 # "~" # jan',
-                     id="inner quotes + comma"),
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan, author = "Paul"}', r'10 # "~" # jan',
-                     id="inner quotes + other field"),
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = "~" # jan}', r'"~" # jan',
-                     id=r'starting quotes'),
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = "~" # jan, }', r'"~" # jan',
-                     id=r'starting quotes + comma'),
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = "~" # jan, author = "Paul"}', r'"~" # jan',
-                     id="starting quotes + other field"),
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = jan # "~"}', r'jan # "~"',
-                     id=r'ending quotes'),
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = jan # "~",}', r'jan # "~"',
-                     id=r'ending quotes + comma'),
-        pytest.param(r'@INBOOK{inbook-full, relevant_field = jan # "~", author = "Paul"}', r'jan # "~"',
-                     id="ending quotes + other field"),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan}',
+            r'10 # "~" # jan',
+            id="inner quotes",
+        ),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan,}',
+            r'10 # "~" # jan',
+            id="inner quotes + comma",
+        ),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = 10 # "~" # jan, author = "Paul"}',
+            r'10 # "~" # jan',
+            id="inner quotes + other field",
+        ),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = "~" # jan}',
+            r'"~" # jan',
+            id=r"starting quotes",
+        ),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = "~" # jan, }',
+            r'"~" # jan',
+            id=r"starting quotes + comma",
+        ),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = "~" # jan, author = "Paul"}',
+            r'"~" # jan',
+            id="starting quotes + other field",
+        ),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = jan # "~"}',
+            r'jan # "~"',
+            id=r"ending quotes",
+        ),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = jan # "~",}',
+            r'jan # "~"',
+            id=r"ending quotes + comma",
+        ),
+        pytest.param(
+            r'@INBOOK{inbook-full, relevant_field = jan # "~", author = "Paul"}',
+            r'jan # "~"',
+            id="ending quotes + other field",
+        ),
     ],
 )
 def test_entry_with_concatenated_field(entry, expected):


### PR DESCRIPTION
This allows the splitter to correctly handle `#`-based string concatenation.

Note: This will still lead to downstream problems, as some of these concatenated fields will not have a recognized enclosing, and as string interpolation does not yet work with concatenated references. However, these cases did not work before either and this this PR does not (knowingly) introduce any regressions. The hereby mentioned problems will be addressed in a subsequent PR.

This is the first pr to address (but not yet close) #396 