### PR TITLE
Add merging of names in last-name-first style

### DIFF
--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -5,7 +5,8 @@ Much of the code is taken from Blair Bonnetts never merged v0 pull request
 """
 import abc
 import dataclasses
-from typing import List, Literal, Tuple
+from typing import List, Tuple
+from typing_extensions import Literal
 
 from bibtexparser.model import Block, Entry, Field, MiddlewareErrorBlock
 

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -5,8 +5,7 @@ Much of the code is taken from Blair Bonnetts never merged v0 pull request
 """
 import abc
 import dataclasses
-from typing import List, Tuple
-from typing_extensions import Literal
+from typing import List, Literal, Tuple
 
 from bibtexparser.model import Block, Entry, Field, MiddlewareErrorBlock
 

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -158,6 +158,9 @@ class MergeNameParts(_NameTransformerMiddleware):
 
     Name fields (e.g. author, editor, translator) are expected to be lists of NameParts.
     """
+    def __init__(self, last_name_first: bool = True, allow_inplace_modification: bool = True, name_fields: Tuple[str] = ("author", "editor", "translator")):
+        self._last_name_first = last_name_first
+        super().__init__(allow_inplace_modification, name_fields)
 
     # docstr-coverage: inherited
     @staticmethod
@@ -168,7 +171,10 @@ class MergeNameParts(_NameTransformerMiddleware):
         if not isinstance(name, list) and all(isinstance(n, NameParts) for n in name):
             raise ValueError("Expected a list of NameParts, got {}. ".format(name))
 
-        return [n.merge_first_name_first for n in name]
+        if self._last_name_first:
+            return [n.merge_last_name_first for n in name]
+        else:
+            return [n.merge_first_name_first for n in name]
 
 
 def parse_single_name_into_parts(name, strict=True):

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -174,7 +174,7 @@ class MergeNameParts(_NameTransformerMiddleware):
 
     The merging style indicates whether:
     - the merging is done without commas in first-name-first order ("first"), or
-    - the merging is done with commas in last-name-first order.
+    - the merging is done with commas in last-name-first order ("last").
     """
 
     def __init__(

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -179,7 +179,7 @@ class MergeNameParts(_NameTransformerMiddleware):
 
     def __init__(
         self,
-        style: Literal["last"] | Literal["first"] = "last",
+        style: Literal["last", "first"] = "last",
         allow_inplace_modification: bool = True,
         name_fields: Tuple[str] = ("author", "editor", "translator"),
     ):

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -113,7 +113,7 @@ class NameParts:
                 if part is not None
             ]
         )
-    
+
     @property
     def merge_last_name_first(self) -> str:
         """Merging the name parts into a single string, last-name-first (with commas) format.
@@ -139,7 +139,9 @@ class NameParts:
         jr = " ".join(self.jr) if self.jr else None
 
         von_last = " ".join(name for name in [von, last] if name)
-        return ", ".join(escape_last_slash(name) for name in [von_last, jr, first] if name)
+        return ", ".join(
+            escape_last_slash(name) for name in [von_last, jr, first] if name
+        )
 
 
 class SplitNameParts(_NameTransformerMiddleware):
@@ -170,7 +172,13 @@ class MergeNameParts(_NameTransformerMiddleware):
 
     Name fields (e.g. author, editor, translator) are expected to be lists of NameParts.
     """
-    def __init__(self, last_name_first: bool = True, allow_inplace_modification: bool = True, name_fields: Tuple[str] = ("author", "editor", "translator")):
+
+    def __init__(
+        self,
+        last_name_first: bool = True,
+        allow_inplace_modification: bool = True,
+        name_fields: Tuple[str] = ("author", "editor", "translator"),
+    ):
         self._last_name_first = last_name_first
         super().__init__(allow_inplace_modification, name_fields)
 

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -113,6 +113,21 @@ class NameParts:
                 if part is not None
             ]
         )
+    
+    @property
+    def merge_last_name_first(self) -> str:
+        """Merging the name parts into a single string, last-name-first (with commas) format.
+
+        The structure of the output is: `von Last, Jr, First`
+        """
+
+        first = " ".join(self.first) if self.first else None
+        von = " ".join(self.von) if self.von else None
+        last = " ".join(self.last) if self.last else None
+        jr = " ".join(self.jr) if self.jr else None
+
+        von_last = " ".join(name for name in [von, last] if name)
+        return ", ".join(name for name in [von_last, jr, first] if name)
 
 
 class SplitNameParts(_NameTransformerMiddleware):

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -5,15 +5,7 @@ Much of the code is taken from Blair Bonnetts never merged v0 pull request
 """
 import abc
 import dataclasses
-from typing import List, Tuple
-
-# Literal is only available in Python 3.8+
-try:
-    from typing import Literal
-
-    FirstOrLastType = Literal["first", "last"]
-except ImportError:
-    FirstOrLastType = str
+from typing import List, Literal, Tuple
 
 from bibtexparser.model import Block, Entry, Field, MiddlewareErrorBlock
 
@@ -187,7 +179,7 @@ class MergeNameParts(_NameTransformerMiddleware):
 
     def __init__(
         self,
-        style: FirstOrLastType = "last",
+        style: Literal["last"] | Literal["first"] = "last",
         allow_inplace_modification: bool = True,
         name_fields: Tuple[str] = ("author", "editor", "translator"),
     ):

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -5,7 +5,14 @@ Much of the code is taken from Blair Bonnetts never merged v0 pull request
 """
 import abc
 import dataclasses
-from typing import List, Literal, Tuple
+from typing import List, Tuple
+
+# Literal is only available in Python 3.8+
+try:
+    from typing import Literal
+    FirstOrLastType = Literal["first", "last"]
+except ImportError:
+    FirstOrLastType = str
 
 from bibtexparser.model import Block, Entry, Field, MiddlewareErrorBlock
 
@@ -179,7 +186,7 @@ class MergeNameParts(_NameTransformerMiddleware):
 
     def __init__(
         self,
-        style: Literal["last"] | Literal["first"] = "last",
+        style: FirstOrLastType = "last",
         allow_inplace_modification: bool = True,
         name_fields: Tuple[str] = ("author", "editor", "translator"),
     ):

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -10,6 +10,7 @@ from typing import List, Tuple
 # Literal is only available in Python 3.8+
 try:
     from typing import Literal
+
     FirstOrLastType = Literal["first", "last"]
 except ImportError:
     FirstOrLastType = str

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -200,7 +200,9 @@ class MergeNameParts(_NameTransformerMiddleware):
         elif self.style == "first":
             return [n.merge_first_name_first for n in name]
         else:
-            raise ValueError("""Expected "first" or "last" style, got {}. """.format(self.style))
+            raise ValueError(
+                """Expected "first" or "last" style, got {}. """.format(self.style)
+            )
 
 
 def parse_single_name_into_parts(name, strict=True):

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -873,7 +873,7 @@ def test_merge_last_name_first_inverse(name, expected_as_dict, strict):
 
     # cases where either the last name or "von" part ends with an odd number of `\` cannot be handled,
     # since in those cases the `,` is escaped when the name parts are put back together
-    def ends_with_odd_slash(names: list[str]) -> bool:
+    def ends_with_odd_slash(names: List[str]) -> bool:
         if len(names) == 0:
             return False
         name = names[-1]

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -987,10 +987,24 @@ def test_split_name_parts(inplace: bool):
 
 
 @pytest.mark.parametrize("inplace", [True, False], ids=["inplace", "copy"])
-@pytest.mark.parametrize(("style", "names"), [
-    ("first", ["Amy Author", "Ben Bystander", "Carl Carpooler\\", "Donald Doctor\\\\"]),
-    ("last", ["Author, Amy", "Bystander, Ben", "Carpooler\\\\, Carl", "Doctor\\\\, Donald"])
-])
+@pytest.mark.parametrize(
+    ("style", "names"),
+    [
+        (
+            "first",
+            ["Amy Author", "Ben Bystander", "Carl Carpooler\\", "Donald Doctor\\\\"],
+        ),
+        (
+            "last",
+            [
+                "Author, Amy",
+                "Bystander, Ben",
+                "Carpooler\\\\, Carl",
+                "Doctor\\\\, Donald",
+            ],
+        ),
+    ],
+)
 def test_merge_name_parts(inplace: bool, style: str, names: list[str]):
     input_entry = Entry(
         start_line=0,
@@ -1013,9 +1027,7 @@ def test_merge_name_parts(inplace: bool, style: str, names: list[str]):
     )
     original_copy = deepcopy(input_entry)
 
-    middleware = MergeNameParts(
-        style=style, allow_inplace_modification=inplace
-    )
+    middleware = MergeNameParts(style=style, allow_inplace_modification=inplace)
     transformed_library = middleware.transform(Library([input_entry]))
 
     assert len(transformed_library.entries) == 1

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -871,9 +871,21 @@ def test_merge_last_name_first_inverse(name, expected_as_dict, strict):
     This property does not hold for certain values that contain '\\'.
     """
 
-    # skip cases with \
-    if any("\\" in "".join(name) for name in expected_as_dict.values()):
-        pytest.skip("Inverse property does not hold for names with '\\'")
+    # cases where either the last name or "von" part ends with an odd number of `\` cannot be handled, 
+    # since in those cases the `,` is escaped when the name parts are put back together
+    def ends_with_odd_slash(names: list[str]) -> bool:
+        if len(names) == 0:
+            return False
+        name = names[-1]
+        count = 0
+        i = len(name) - 1
+        while i >= 0 and name[i] == "\\":
+            count += 1
+            i -= 1
+        return count % 2 == 1
+    
+    if any(ends_with_odd_slash(name) for name in expected_as_dict.values()):
+        pytest.skip("Inverse property does not hold for names ending with '\\'")
 
     nameparts = _dict_to_nameparts(expected_as_dict)
     merged = nameparts.merge_last_name_first

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -1005,7 +1005,7 @@ def test_split_name_parts(inplace: bool):
         ),
     ],
 )
-def test_merge_name_parts(inplace: bool, style: str, names: list[str]):
+def test_merge_name_parts(inplace: bool, style: str, names: List[str]):
     input_entry = Entry(
         start_line=0,
         raw="irrelevant-for-this-test",

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -871,7 +871,7 @@ def test_merge_last_name_first_inverse(name, expected_as_dict, strict):
     This property does not hold for certain values that contain '\\'.
     """
 
-    # cases where either the last name or "von" part ends with an odd number of `\` cannot be handled, 
+    # cases where either the last name or "von" part ends with an odd number of `\` cannot be handled,
     # since in those cases the `,` is escaped when the name parts are put back together
     def ends_with_odd_slash(names: list[str]) -> bool:
         if len(names) == 0:
@@ -883,7 +883,7 @@ def test_merge_last_name_first_inverse(name, expected_as_dict, strict):
             count += 1
             i -= 1
         return count % 2 == 1
-    
+
     if any(ends_with_odd_slash(name) for name in expected_as_dict.values()):
         pytest.skip("Inverse property does not hold for names ending with '\\'")
 

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -987,8 +987,11 @@ def test_split_name_parts(inplace: bool):
 
 
 @pytest.mark.parametrize("inplace", [True, False], ids=["inplace", "copy"])
-@pytest.mark.parametrize("style", ["first", "last"])
-def test_merge_name_parts(inplace: bool, style: str):
+@pytest.mark.parametrize(("style", "names"), [
+    ("first", ["Amy Author", "Ben Bystander", "Carl Carpooler\\", "Donald Doctor\\\\"]),
+    ("last", ["Author, Amy", "Bystander, Ben", "Carpooler\\\\, Carl", "Doctor\\\\, Donald"])
+])
+def test_merge_name_parts(inplace: bool, style: str, names: list[str]):
     input_entry = Entry(
         start_line=0,
         raw="irrelevant-for-this-test",
@@ -1002,6 +1005,8 @@ def test_merge_name_parts(inplace: bool, style: str):
                 value=[
                     NameParts(first=["Amy"], last=["Author"], von=[], jr=[]),
                     NameParts(first=["Ben"], last=["Bystander"], von=[], jr=[]),
+                    NameParts(first=["Carl"], last=["Carpooler\\"], von=[], jr=[]),
+                    NameParts(first=["Donald"], last=["Doctor\\\\"], von=[], jr=[]),
                 ],
             ),
         ],
@@ -1018,16 +1023,7 @@ def test_merge_name_parts(inplace: bool, style: str):
 
     transformed_entry = transformed_library.entries[0]
     assert transformed_entry.fields_dict["title"] == original_copy.fields_dict["title"]
-    if style == "last":
-        assert transformed_entry.fields_dict["author"].value == [
-            "Author, Amy",
-            "Bystander, Ben",
-        ]
-    else:
-        assert transformed_entry.fields_dict["author"].value == [
-            "Amy Author",
-            "Ben Bystander",
-        ]
+    assert transformed_entry.fields_dict["author"].value == names
 
     # Make sure other attributes are not changed
     assert_nonfield_entry_attributes_unchanged(original_copy, transformed_entry)

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -965,7 +965,7 @@ def test_merge_name_parts(inplace: bool):
     )
     original_copy = deepcopy(input_entry)
 
-    middleware = MergeNameParts(allow_inplace_modification=inplace)
+    middleware = MergeNameParts(last_name_first=False, allow_inplace_modification=inplace)
     transformed_library = middleware.transform(Library([input_entry]))
 
     assert len(transformed_library.entries) == 1

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -859,6 +859,7 @@ def test_split_name_into_parts(name, expected_as_dict, strict):
     expected = _dict_to_nameparts(expected_as_dict)
     assert result == expected
 
+
 @pytest.mark.parametrize(
     "name, expected_as_dict", REGULAR_NAME_PARTS_PARSING_TEST_CASES
 )
@@ -869,7 +870,7 @@ def test_merge_last_name_first_inverse(name, expected_as_dict, strict):
 
     This property does not hold for certain values that contain '\\'.
     """
-    
+
     # skip cases with \
     if any("\\" in "".join(name) for name in expected_as_dict.values()):
         pytest.skip("Inverse property does not hold for names with '\\'")
@@ -986,7 +987,9 @@ def test_split_name_parts(inplace: bool):
 
 
 @pytest.mark.parametrize("inplace", [True, False], ids=["inplace", "copy"])
-@pytest.mark.parametrize("last_name_first", [True, False], ids=["last name first", "first name first"])
+@pytest.mark.parametrize(
+    "last_name_first", [True, False], ids=["last name first", "first name first"]
+)
 def test_merge_name_parts(inplace: bool, last_name_first: bool):
     input_entry = Entry(
         start_line=0,
@@ -1007,7 +1010,9 @@ def test_merge_name_parts(inplace: bool, last_name_first: bool):
     )
     original_copy = deepcopy(input_entry)
 
-    middleware = MergeNameParts(last_name_first=last_name_first, allow_inplace_modification=inplace)
+    middleware = MergeNameParts(
+        last_name_first=last_name_first, allow_inplace_modification=inplace
+    )
     transformed_library = middleware.transform(Library([input_entry]))
 
     assert len(transformed_library.entries) == 1

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -838,6 +838,21 @@ def test_split_name_into_parts(name, expected_as_dict, strict):
     expected = _dict_to_nameparts(expected_as_dict)
     assert result == expected
 
+@pytest.mark.parametrize(
+    "name, expected_as_dict", REGULAR_NAME_PARTS_PARSING_TEST_CASES
+)
+@pytest.mark.parametrize("strict", [True, False], ids=["strict", "non-strict"])
+def test_merge_last_name_first_inverse(name, expected_as_dict, strict):
+    """Tests that merging name parts using the last-name-first method
+    maintains the "semantics" of the name.
+    
+    In other words, last-name-first merging is the (right) inverse of splitting.
+    """
+    nameparts = _dict_to_nameparts(expected_as_dict)
+    merged = nameparts.merge_last_name_first
+    resplit = parse_single_name_into_parts(merged, strict=strict)
+    assert resplit == nameparts
+
 
 @pytest.mark.parametrize("inplace", [True, False], ids=["inplace", "copy"])
 def test_separate_co_names_middleware(inplace):

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -866,9 +866,14 @@ def test_split_name_into_parts(name, expected_as_dict, strict):
 def test_merge_last_name_first_inverse(name, expected_as_dict, strict):
     """Tests that merging name parts using the last-name-first method
     maintains the "semantics" of the name.
-    
-    In other words, last-name-first merging is the (right) inverse of splitting.
+
+    This property does not hold for certain values that contain '\\'.
     """
+    
+    # skip cases with \
+    if any("\\" in "".join(name) for name in expected_as_dict.values()):
+        pytest.skip("Inverse property does not hold for names with '\\'")
+
     nameparts = _dict_to_nameparts(expected_as_dict)
     merged = nameparts.merge_last_name_first
     resplit = parse_single_name_into_parts(merged, strict=strict)

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -945,7 +945,8 @@ def test_split_name_parts(inplace: bool):
 
 
 @pytest.mark.parametrize("inplace", [True, False], ids=["inplace", "copy"])
-def test_merge_name_parts(inplace: bool):
+@pytest.mark.parametrize("last_name_first", [True, False], ids=["last name first", "first name first"])
+def test_merge_name_parts(inplace: bool, last_name_first: bool):
     input_entry = Entry(
         start_line=0,
         raw="irrelevant-for-this-test",
@@ -965,7 +966,7 @@ def test_merge_name_parts(inplace: bool):
     )
     original_copy = deepcopy(input_entry)
 
-    middleware = MergeNameParts(last_name_first=False, allow_inplace_modification=inplace)
+    middleware = MergeNameParts(last_name_first=last_name_first, allow_inplace_modification=inplace)
     transformed_library = middleware.transform(Library([input_entry]))
 
     assert len(transformed_library.entries) == 1
@@ -973,10 +974,16 @@ def test_merge_name_parts(inplace: bool):
 
     transformed_entry = transformed_library.entries[0]
     assert transformed_entry.fields_dict["title"] == original_copy.fields_dict["title"]
-    assert transformed_entry.fields_dict["author"].value == [
-        "Amy Author",
-        "Ben Bystander",
-    ]
+    if last_name_first:
+        assert transformed_entry.fields_dict["author"].value == [
+            "Author, Amy",
+            "Bystander, Ben",
+        ]
+    else:
+        assert transformed_entry.fields_dict["author"].value == [
+            "Amy Author",
+            "Ben Bystander",
+        ]
 
     # Make sure other attributes are not changed
     assert_nonfield_entry_attributes_unchanged(original_copy, transformed_entry)

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -987,10 +987,8 @@ def test_split_name_parts(inplace: bool):
 
 
 @pytest.mark.parametrize("inplace", [True, False], ids=["inplace", "copy"])
-@pytest.mark.parametrize(
-    "last_name_first", [True, False], ids=["last name first", "first name first"]
-)
-def test_merge_name_parts(inplace: bool, last_name_first: bool):
+@pytest.mark.parametrize("style", ["first", "last"])
+def test_merge_name_parts(inplace: bool, style: str):
     input_entry = Entry(
         start_line=0,
         raw="irrelevant-for-this-test",
@@ -1011,7 +1009,7 @@ def test_merge_name_parts(inplace: bool, last_name_first: bool):
     original_copy = deepcopy(input_entry)
 
     middleware = MergeNameParts(
-        last_name_first=last_name_first, allow_inplace_modification=inplace
+        style=style, allow_inplace_modification=inplace
     )
     transformed_library = middleware.transform(Library([input_entry]))
 
@@ -1020,7 +1018,7 @@ def test_merge_name_parts(inplace: bool, last_name_first: bool):
 
     transformed_entry = transformed_library.entries[0]
     assert transformed_entry.fields_dict["title"] == original_copy.fields_dict["title"]
-    if last_name_first:
+    if style == "last":
         assert transformed_entry.fields_dict["author"].value == [
             "Author, Amy",
             "Bystander, Ben",


### PR DESCRIPTION
I added a flag to `MergeNameParts` so the user can decide whether to use first-name-first or last-name-first.
I made last-name-first the default.

I slightly modified one existing test group to support the flag.

I added a new test group `test_merge_last_name_first_inverse` which ensures that merging with commas is the inverse of splitting. I skip this test for cases including a `/`, since this property doesn't hold for some of those cases.

I also had to do a bit of strange stuff with the typing imports. The flag I added is a union of literal strings, but literal string types aren't available in Python 3.7. So I try importing a literal type and if that doesn't work then I just say the type of the flag is "str", which is too general but the closest I can get 