### PR TITLE
:bug: Fix bug in `von`-part name parsing

### DIFF
--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -424,11 +424,17 @@ def parse_single_name_into_parts(name, strict=True):
         else:
             lcases = cases[0]
 
-            #
+            def rindex(l, x, default):
+                """Returns the index of the rightmost occurence of x in l."""
+                for i in range(len(l) - 1, -1, -1):
+                    if l[i] == x:
+                        return i
+                return default
+
+            # Check if at least one of the words is lowercase
             if 0 in lcases:
-                split = len(lcases) - lcases[::-1].index(0)
-                if split == len(lcases):
-                    split = 0  # Last cannot be empty.
+                # Excluding the last word, find the index of the last lower word
+                split = rindex(lcases[:-1], 0, -1) + 1
                 parts.von = sections[0][:split]
                 parts.last = sections[0][split:]
 

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -825,6 +825,27 @@ REGULAR_NAME_PARTS_PARSING_TEST_CASES = (
         r"Brand\~{a}o, F",
         {"first": ["F"], "von": [], "last": ["Brand\\", "{a}o"], "jr": []},
     ),
+    ###############################################################################
+    #
+    # Group 2 examples from Tame the BeaST
+    #
+    ###############################################################################
+    (
+        r"de la fontaine, Jean",
+        {"first": ["Jean"], "von": ["de", "la"], "last": ["fontaine"], "jr": []},
+    ),
+    (
+        r"De La Fontaine, Jean",
+        {"first": ["Jean"], "von": [], "last": ["De", "La", "Fontaine"], "jr": []},
+    ),
+    (
+        r"De la Fontaine, Jean",
+        {"first": ["Jean"], "von": ["De", "la"], "last": ["Fontaine"], "jr": []},
+    ),
+    (
+        r"de La Fontaine, Jean",
+        {"first": ["Jean"], "von": ["de"], "last": ["La", "Fontaine"], "jr": []},
+    ),
 )
 
 


### PR DESCRIPTION
The current system has a name parsing issue around capitalization in comma-style names. This means that

```
aa bb, CC
```

gets parsed as

```
last: aa bb
first: CC
von: <empty>
```

but BibTeX parses this as

```
last: bb
first: CC
von: aa
```

I have modified the parsing code and added relevant test cases drawn from the Tame The BeaST BibTeX reference document.

Style-wise, I found the list manipulation difficult to follow; I added a helper function `rindex`, which makes it easier to understand IMO. This should probably go in a utility file or something, but I didn't see one in the project.

I believe these changes will fix at least some of the failing test cases in the name merging PR here: #422 