### PR TITLE
Use raw strings to fix invalid escape (V1)

### DIFF
--- a/bibtexparser/latexenc.py
+++ b/bibtexparser/latexenc.py
@@ -90,7 +90,7 @@ def protect_uppercase(string):
     :param string: string to convert
     :returns: string
     """
-    string = re.sub('([^{]|^)([A-Z])([^}]|$)', '\g<1>{\g<2>}\g<3>', string)
+    string = re.sub(r'([^{]|^)([A-Z])([^}]|$)', r'\g<1>{\g<2>}\g<3>', string)
     return string
 
 


### PR DESCRIPTION
The replacement string contains `\g`, which is an invalid escape in Python (and not supposed to be a python escape).