### PR TITLE
`Entry`: Dict-mimicking `in` operator.

### DIFF
--- a/bibtexparser/model.py
+++ b/bibtexparser/model.py
@@ -314,6 +314,10 @@ class Entry(Block):
         self._fields = [f for f in self._fields if f.key != key]
         return field
 
+    def __contains__(self, key: str) -> bool:
+        """Dict-mimicking ``in`` operator."""
+        return key in self.fields_dict
+
     def __getitem__(self, key: str) -> Any:
         """Dict-mimicking index.
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -77,6 +77,12 @@ def test_entry_deepcopy():
     assert entry_1.fields_dict["field"] == entry_2.fields_dict["field"]
 
 
+def test_entry_contain():
+    entry = Entry("article", "key", [Field("field", "value", 1)], 1, "raw")
+    assert "field" in entry
+    assert "other" not in entry
+
+
 def test_string_equality():
     # Equal to itself
     string_1 = String(


### PR DESCRIPTION
Fixes https://github.com/sciunto-org/python-bibtexparser/issues/454