### PR TITLE
Rename `pop_field` -> `pop` (with default) to make API closer to `dict`

### DIFF
--- a/bibtexparser/model.py
+++ b/bibtexparser/model.py
@@ -305,12 +305,15 @@ class Entry(Block):
         else:
             self._fields.append(field)
 
-    def pop_field(self, key: str) -> Optional[Field]:
-        """Removes and returns the field with the given key, if present."""
+    def pop(self, key: str, default=None) -> Optional[Field]:
+        """Removes and returns the field with the given key.
+
+        :param key: The key of the field to remove.
+        :param default: The value to return if the field does not exist."""
         try:
             field = self.fields_dict.pop(key)
         except KeyError:
-            return None
+            return default
 
         self._fields = [f for f in self._fields if f.key != key]
         return field
@@ -345,9 +348,9 @@ class Entry(Block):
         """Dict-mimicking index.
 
         This serves for partial v1.x backwards compatibility,
-        as well as for a shorthand for `pop_field`.
+        as well as for a shorthand for `pop`.
         """
-        self.pop_field(key)
+        self.pop(key)
 
     def items(self):
         """Dict-mimicking, for partial v1.x backwards compatibility.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -77,7 +77,17 @@ def test_entry_deepcopy():
     assert entry_1.fields_dict["field"] == entry_2.fields_dict["field"]
 
 
-def test_entry_contain():
+def test_entry_pop():
+    entry1 = Entry(
+        "article", "key", [Field("field", "value", 1), Field("foo", "bar", 2)], 1, "raw"
+    )
+    entry2 = Entry("article", "key", [Field("field", "value", 1)], 1, "raw")
+    assert entry1.pop("other", "default") == "default"
+    assert entry1.pop("foo") == Field("foo", "bar", 2)
+    assert entry1 == entry2
+
+
+def test_entry_contains():
     entry = Entry("article", "key", [Field("field", "value", 1)], 1, "raw")
     assert "field" in entry
     assert "other" not in entry


### PR DESCRIPTION
Fixes https://github.com/sciunto-org/python-bibtexparser/issues/461