### PR TITLE
:bug: fix `split_multiple_persons_names` with single-char middlenames

### DIFF
--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -600,8 +600,8 @@ def split_multiple_persons_names(names):
                 step = FIND_A
                 possible_end = pos - 1
 
-        # Looking for the letter a. NB., we can have multiple whitespace
-        # characters so we need to handle that here.
+        # Looking for the letter "a".
+        # NB, we can have multiple whitespace characters so we need to handle that here.
         elif step == FIND_A:
             if char in ("a", "A"):
                 step = FIND_N
@@ -612,6 +612,9 @@ def split_multiple_persons_names(names):
         elif step == FIND_N:
             if char in ("n", "N"):
                 step = FIND_D
+            elif char in whitespace:
+                step = FIND_A
+                possible_end = pos - 1
             else:
                 step = START_WHITESPACE
 
@@ -619,6 +622,9 @@ def split_multiple_persons_names(names):
         elif step == FIND_D:
             if char in ("d", "D"):
                 step = END_WHITESPACE
+            elif char in whitespace:
+                step = FIND_A
+                possible_end = pos - 1
             else:
                 step = START_WHITESPACE
 

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -75,6 +75,8 @@ from tests.middleware_tests.middleware_test_util import assert_nonfield_entry_at
         ("Harry Fellowes~and D. Drumpf", ["Harry Fellowes~and D. Drumpf"]),
         ("Harry Fellowes~and~D. Drumpf", ["Harry Fellowes~and~D. Drumpf"]),
         ("Harry Fellowes and~D. Drumpf", ["Harry Fellowes and~D. Drumpf"]),
+        ("Doe, John A and Doe, Jane", ["Doe, John A", "Doe, Jane"]),
+        ("Doe, John AN and Doe, Jane", ["Doe, John AN", "Doe, Jane"]),
         ("      ", []),
         ("\t\n \t", []),
         ("~", ["~"]),


### PR DESCRIPTION
Fixes https://github.com/sciunto-org/python-bibtexparser/issues/475