### PR TITLE
✨ Use dedicated logger

### DIFF
--- a/bibtexparser/middlewares/fieldkeys.py
+++ b/bibtexparser/middlewares/fieldkeys.py
@@ -9,6 +9,8 @@ from bibtexparser.model import Field
 
 from .middleware import BlockMiddleware
 
+logger = logging.getLogger(__name__)
+
 
 class NormalizeFieldKeys(BlockMiddleware):
     """Normalize field keys to lowercase.
@@ -37,7 +39,7 @@ class NormalizeFieldKeys(BlockMiddleware):
             # if performance is a concern, we could emit a warning with only {entry.key}
             # to remove "seen_normalized_keys" and this if statement
             if normalized_key in seen_normalized_keys:
-                logging.warning(
+                logger.warning(
                     f"NormalizeFieldKeys: in entry '{entry.key}': "
                     + f"duplicate normalized key '{normalized_key}' "
                     + f"(original '{field.key}'); overriding previous value"

--- a/bibtexparser/middlewares/latex_encoding.py
+++ b/bibtexparser/middlewares/latex_encoding.py
@@ -22,6 +22,8 @@ from bibtexparser.model import String
 from .middleware import BlockMiddleware
 from .names import NameParts
 
+logger = logging.getLogger(__name__)
+
 
 class _PyStringTransformerMiddleware(BlockMiddleware, abc.ABC):
     """Abstract utility class allowing to modify python-strings"""
@@ -59,7 +61,7 @@ class _PyStringTransformerMiddleware(BlockMiddleware, abc.ABC):
                 field.value.von = self._transform_all_strings(field.value.von, errors)
                 field.value.jr = self._transform_all_strings(field.value.jr, errors)
             else:
-                logging.info(
+                logger.info(
                     f" [{self.metadata_key()}] Cannot python-str transform field {field.key}"
                     f" with value type {type(field.value)}"
                 )
@@ -76,7 +78,7 @@ class _PyStringTransformerMiddleware(BlockMiddleware, abc.ABC):
         if isinstance(string.value, str):
             string.value = self._transform_python_value_string(string.value)
         else:
-            logging.info(
+            logger.info(
                 f" [{self.metadata_key()}] Cannot python-str transform string {string.key}"
                 f" with value type {type(string.value)}"
             )

--- a/bibtexparser/middlewares/middleware.py
+++ b/bibtexparser/middlewares/middleware.py
@@ -12,6 +12,8 @@ from bibtexparser.model import ImplicitComment
 from bibtexparser.model import Preamble
 from bibtexparser.model import String
 
+logger = logging.getLogger(__name__)
+
 
 class Middleware(abc.ABC):
     """Implements a function to transform a block or library.
@@ -128,7 +130,7 @@ class BlockMiddleware(Middleware, abc.ABC):
         elif isinstance(block, ImplicitComment):
             return self.transform_implicit_comment(block, library)
 
-        logging.warning(f"Unknown block type {type(block)}")
+        logger.warning(f"Unknown block type {type(block)}")
         return block
 
     def transform_entry(

--- a/bibtexparser/splitter.py
+++ b/bibtexparser/splitter.py
@@ -19,6 +19,8 @@ from .model import ParsingFailedBlock
 from .model import Preamble
 from .model import String
 
+logger = logging.getLogger(__name__)
+
 
 class Splitter:
     """Object responsible for splitting a BibTeX string into blocks.
@@ -254,7 +256,7 @@ class Splitter:
         if library is None:
             library = Library()
         else:
-            logging.info("Adding blocks to existing library.")
+            logger.info("Adding blocks to existing library.")
 
         while True:
             m = self._next_mark(accept_eof=True)
@@ -283,12 +285,12 @@ class Splitter:
                         library.add(self._handle_entry(m, m_val))
 
                 except BlockAbortedException as e:
-                    logging.warning(
+                    logger.warning(
                         f"Parsing of `{m_val}` block (line {start_line}) "
                         f"aborted on line {self._current_line} "
                         f"due to syntactical error in bibtex:\n {e.abort_reason}"
                     )
-                    logging.info(
+                    logger.info(
                         "We will try to continue parsing, but this might lead to unexpected results."
                         "The failed block will be stored in the `failed_blocks`of the library."
                     )
@@ -302,14 +304,14 @@ class Splitter:
 
                 except ParserStateException as e:
                     # This is a bug in the parser, not in the bibtex. We should not continue.
-                    logging.error(
+                    logger.error(
                         "python-bibtexparser detected an invalid state. Please report this bug."
                     )
-                    logging.error(e.message)
+                    logger.error(e.message)
                     raise e
                 except Exception as e:
                     # For unknown exeptions, we want to fail hard and get the info in our issue tracker.
-                    logging.error(
+                    logger.error(
                         f"Unexpected exception while parsing `{m_val}` block (line {start_line})"
                         "Please report this bug."
                     )

--- a/tests/middleware_tests/test_fieldkeys.py
+++ b/tests/middleware_tests/test_fieldkeys.py
@@ -62,7 +62,9 @@ def test_normalize_fieldkeys_force_last(caplog):
         lib.add(Entry(entry_type=entry_type, key=f"entry{i}", fields=f))
 
     lib = NormalizeFieldKeys().transform(lib)
-    assert re.match(r"(WARNING\s*)(\w*\:\w*\.py\:[0-9]*\s*)(NormalizeFieldKeys)(.*)", caplog.text)
+    assert re.match(
+        r"(WARNING\s*)([\w\.]*\:\w*\.py\:[0-9]*\s*)(NormalizeFieldKeys)(.*)", caplog.text
+    )
 
     for key in lib.entries_dict:
         assert lib.entries_dict[key] == ref.entries_dict[key]


### PR DESCRIPTION
This PR replaces all occurrences of the root logger with a dedicated logger.

Calls to `logging.<method>` use the root logger. As explained in [this section](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) of the python docs, it is recommended to use a dedicated logger.