### PR TITLE
Support custom encoding when writing BibTeX files

### DIFF
--- a/bibtexparser/entrypoint.py
+++ b/bibtexparser/entrypoint.py
@@ -139,6 +139,7 @@ def write_file(
     parse_stack: Optional[Iterable[Middleware]] = None,
     append_middleware: Optional[Iterable[Middleware]] = None,
     bibtex_format: Optional[BibtexFormat] = None,
+    encoding: str = "UTF-8",
 ) -> None:
     """Write a BibTeX database to a file.
 
@@ -156,7 +157,7 @@ def write_file(
         bibtex_format=bibtex_format,
     )
     if isinstance(file, str):
-        with open(file, "w") as f:
+        with open(file, "w", encoding=encoding) as f:
             f.write(bibtex_str)
     else:
         file.write(bibtex_str)


### PR DESCRIPTION
Add encoding parameter to file writing function.

Solves the `UnicodeEncodeError` at write time.

<details>
<summary>Error Stacktrace</summary>

```
Traceback (most recent call last):
  File "c:\Users\usr\documents\scripts\bib_parser.py", line 103, in <module>
    clean_bib()
    ~~~~~~~~~^^
  File "c:\Users\usr\documents\scripts\bib_parser.py", line 98, in clean_bib
    bibtexparser.write_file(bibtex_file, bibtex_database)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\usr\AppData\Local\miniconda3\Lib\site-packages\bibtexparser\entrypoint.py", line 160, in write_file
    f.write(bibtex_str)
    ~~~~~~~^^^^^^^^^^^^
  File "C:\Users\usr\AppData\Local\miniconda3\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u2010' in position 2731: character maps to <undefined>
```

</details>