### PR TITLE
✨ Add encoding validation in parse_file()

### DIFF
--- a/bibtexparser/entrypoint.py
+++ b/bibtexparser/entrypoint.py
@@ -1,3 +1,4 @@
+import codecs
 import warnings
 from typing import Iterable
 from typing import List
@@ -125,7 +126,13 @@ def parse_file(
 
     :param encoding: Encoding of the .bib file. Default encoding is ``"UTF-8"``.
     :return: Library: Parsed BibTeX library
+    :raises LookupError: If the specified encoding is not recognized.
     """
+    try:
+        codecs.lookup(encoding)
+    except LookupError:
+        raise LookupError(f"Unknown encoding: {encoding!r}")
+
     with open(path, encoding=encoding) as f:
         bibtex_str = f.read()
         return parse_string(


### PR DESCRIPTION
Validate encoding parameter with `codecs.lookup()` before opening file for clearer error messages.