### PR TITLE
✏️ Fix typos in error messages

### DIFF
--- a/bibtexparser/entrypoint.py
+++ b/bibtexparser/entrypoint.py
@@ -20,9 +20,9 @@ def _build_parse_stack(
 ) -> List[Middleware]:
     if parse_stack is not None and append_middleware is not None:
         raise ValueError(
-            "Provided both parse_stack and append_middleware."
-            "Only one should be provided."
-            "(append_middleware should only be used with the default parse_stack,"
+            "Provided both parse_stack and append_middleware. "
+            "Only one should be provided. "
+            "(append_middleware should only be used with the default parse_stack, "
             "i.e., when the passed parse_stack is None.)"
         )
 
@@ -50,10 +50,10 @@ def _build_unparse_stack(
 ) -> List[Middleware]:
     if unparse_stack is not None and prepend_middleware is not None:
         raise ValueError(
-            "Provided both parse_stack and append_middleware."
-            "Only one should be provided."
-            "(prepend_middleware should only be used with the default parse_stack,"
-            "i.e., when the passed parse_stack is None.)"
+            "Provided both unparse_stack and prepend_middleware. "
+            "Only one should be provided. "
+            "(prepend_middleware should only be used with the default unparse_stack, "
+            "i.e., when the passed unparse_stack is None.)"
         )
 
     if unparse_stack is None:

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -164,8 +164,8 @@ class SplitNameParts(_NameTransformerMiddleware):
         if not isinstance(name, list):
             raise ValueError(
                 "Expected a list of strings, got {}. "
-                "Make sure to use `SeparateCoAuthors` middleware"
-                "before using `SplitNameParts` middleware".format(name)
+                "Make sure to use `SeparateCoAuthors` middleware "
+                "before using `SplitNameParts` middleware.".format(name)
             )
 
         return [parse_single_name_into_parts(n) for n in name]


### PR DESCRIPTION
Fix missing spaces between concatenated strings and correct parameter names in `_build_unparse_stack` error message.