### PR TITLE
:bug: Fix undefined variable references in write_file (introduced in last commit)

### DIFF
--- a/bibtexparser/entrypoint.py
+++ b/bibtexparser/entrypoint.py
@@ -151,8 +151,8 @@ def write_file(
     :param bibtex_format: Customized BibTeX format to use (optional)."""
     bibtex_str = write_string(
         library=library,
-        unparse_stack=parse_stack,
-        prepend_middleware=append_middleware,
+        unparse_stack=unparse_stack,
+        prepend_middleware=prepend_middleware,
         bibtex_format=bibtex_format,
     )
     if isinstance(file, str):


### PR DESCRIPTION
## Summary
Fix bug introduced in PR #489 where `write_file()` was referencing undefined variables (`parse_stack`/`append_middleware`) instead of the renamed function parameters (`unparse_stack`/`prepend_middleware`).
