### PR TITLE
:pushpin: Pin pylatexenc to major version 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "pylatexenc>=2.10",
+        "pylatexenc~=2.10",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Use compatible release operator to prevent installing pylatexenc 3.x (currently in beta, compatibility not yet tested)