### PR TITLE
docs: fix broken links to default_parse_stack and default_unparse_stack

### DIFF
--- a/docs/source/bibtexparser.rst
+++ b/docs/source/bibtexparser.rst
@@ -38,3 +38,8 @@ Full API
 
 .. autoclass:: bibtexparser.BibtexFormat
     :members:
+
+:mod:`bibtexparser.middlewares.parsestack` --- Default parse/unparse stacks
+-----------------------------------------------------------------------------
+.. automodule:: bibtexparser.middlewares.parsestack
+    :members:

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -40,18 +40,19 @@ This example adds three new middleware layers to the parse stack:
 2. The second layer splits the author field into a list of authors (and similarly for editors, translators, etc.).
 3. The third layer splits the author names into a object representing the first, von, last and jr parts of the name.
 
-Default Parse-Stack
-^^^^^^^^^^^^^^^^^^^
+Default Parse and Write Stacks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-BibtexParser foresees a default parse stack; i.e., some middleware is automatically applied as we assume it to be
-part of the expected functionality for most users.
+BibtexParser applies a default middleware stack when parsing and writing.
+These stacks are built by :func:`~bibtexparser.middlewares.parsestack.default_parse_stack`
+and :func:`~bibtexparser.middlewares.parsestack.default_unparse_stack`, respectively.
 
-Currently, the default parse stack consists of the following layers:
+**Parse stack:**
 
 * :class:`bibtexparser.middlewares.ResolveStringReferencesMiddleware`: De-Reference reference to @string definitions.
 * :class:`bibtexparser.middlewares.RemoveEnclosingMiddleware`: Removes enclosing (e.g. curly braces or "") from values.
 
-The default write stack consists of the following layers:
+**Write stack:**
 
 * :class:`bibtexparser.middlewares.AddEnclosingMiddleware`: Encloses values in curly braces where needed.
 


### PR DESCRIPTION
## Summary

Fixes #469 — documentation links to the default parse and write stacks are now resolvable.

**Problem:** The Customize page referenced the default middleware stacks without linking to the functions that build them. The RST used  links to middleware classes rather than  links to  and , making those links appear as dead links on the rendered docs.

**Changes:**

1. **docs/source/customize.rst**: Updated the 'Default Parse and Write Stacks' section to explicitly reference  and , which are the actual builder functions.

2. **docs/source/bibtexparser.rst**: Added  to the API reference with  so Sphinx autodoc generates links for the functions.

## Test Plan
- [x] Documentation builds without warnings ()
- [x]  and  appear as linked references in the rendered docs

Closes #469