### PR TITLE
💚 Run unittest workflow on all pushes

### DIFF
--- a/.github/workflows/linting_and_unittests.yml
+++ b/.github/workflows/linting_and_unittests.yml
@@ -2,8 +2,6 @@ name: "unittests"
 
 on:
   push:
-    paths:
-    - '**.py'
   pull_request:
     branches: ["main"]
 


### PR DESCRIPTION
The push trigger was limited to `**.py` paths, so changes to pyproject.toml, workflows, or test resources did not run the test suite.

Fixes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)