### PR TITLE
🐛 Fix swapped month metadata messages in MonthIntMiddleware

### DIFF
--- a/bibtexparser/middlewares/month.py
+++ b/bibtexparser/middlewares/month.py
@@ -199,12 +199,12 @@ class MonthIntMiddleware(_MonthInterpolator):
             if v_lower in _MONTH_ABBREV:
                 return (
                     _MONTH_ABBREV.index(v_lower[:3]) + 1,
-                    "transformed full month to int-month",
+                    "transformed abbreviated month to int-month",
                 )
             elif v_lower in _LOWERCASE_FULL:
                 return (
                     _LOWERCASE_FULL.index(v_lower) + 1,
-                    "transformed abbreviated month to int-month",
+                    "transformed full month to int-month",
                 )
 
         if isinstance(v, str) and v.isdigit():


### PR DESCRIPTION
The abbreviation branch reported "transformed full month to int-month" and the full-name branch reported "transformed abbreviated month to int-month" — swapped.

Fixes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)