### PR TITLE
📝 Fix README/RELEASE/docs cosmetics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Go check out our documentation on [https://bibtexparser.readthedocs.io/en/main/]
 - :rocket: Order of magnitudes faster
 - :wrench: Easily customizable parsing **and** writing
 - :herb: Access to raw, unparsed bibtex.
-- :hankey: Fault-Tolerant: Able to parse files with syntax errors
-- :mahjong: Massively simplified, robuster handling of de- and encoding (special chars, ...).
+- :shield: Fault-Tolerant: Able to parse files with syntax errors
+- :mahjong: Massively simplified, more robust handling of de- and encoding (special chars, ...).
 - :copyright: Permissive MIT license
 
 ## TLDR Usage Example

--- a/RELEASE
+++ b/RELEASE
@@ -1,12 +1,12 @@
 Tagged version are automatically released to pypi using github actions.
 
-Oder/Manual release instructions:
+Alternative manual release instructions:
 
 * Update CHANGELOG
 * Update version in __init__.py
 * Commit and open PR on Github to see that all tests pass,
   and then merge the PR.
-* Check out master locally
+* Check out main locally
 * Build sdist and wheel
     python -m build
 * Check long description

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "BibtexParser"
-copyright = "2013-2023, M. Weiss, F. Boulogne and other contributors"
+copyright = "2013-2026, M. Weiss, F. Boulogne and other contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
- docs copyright year range updated
- README: \"robuster\" → \"more robust\"; replace 💩 emoji on the Fault-Tolerant bullet
- RELEASE: \"Oder/Manual\" typo, master → main

Fixes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)