### PR TITLE
🐛 Fix AddEnclosingMiddleware.metadata_key identifier

### DIFF
--- a/bibtexparser/middlewares/enclosing.py
+++ b/bibtexparser/middlewares/enclosing.py
@@ -139,7 +139,7 @@ class AddEnclosingMiddleware(BlockMiddleware):
     # docstr-coverage: inherited
     @classmethod
     def metadata_key(cls) -> str:
-        return "remove_enclosing"
+        return "add_enclosing"
 
     def _enclose(
         self,


### PR DESCRIPTION
AddEnclosingMiddleware.metadata_key() returned "remove_enclosing" — a copy-paste remnant nearly colliding with RemoveEnclosingMiddleware's "removed_enclosing" and not identifying the middleware itself. Now returns "add_enclosing".

Fixes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)