### PR TITLE
🐛 Return a copy in Library.strings_dict

### DIFF
--- a/bibtexparser/library.py
+++ b/bibtexparser/library.py
@@ -196,7 +196,7 @@ class Library:
     @property
     def strings_dict(self) -> Dict[str, String]:
         """Dict representation of all @string blocks in the library."""
-        return self._strings_by_key
+        return self._strings_by_key.copy()
 
     @property
     def entries(self) -> List[Entry]:


### PR DESCRIPTION
Library.strings_dict returned the internal dict, so external mutation corrupted the library's state — while entries_dict already returns a copy. Now both return copies.

Fixes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)