### PR TITLE
🎨 Align middleware override signatures with base class

### DIFF
--- a/bibtexparser/middlewares/enclosing.py
+++ b/bibtexparser/middlewares/enclosing.py
@@ -167,7 +167,7 @@ class AddEnclosingMiddleware(BlockMiddleware):
         )
 
     # docstr-coverage: inherited
-    def transform_entry(self, entry: Entry, *args, **kwargs) -> Entry:
+    def transform_entry(self, entry: Entry, library: Library) -> Entry:
         field: Field
         metadata_enclosing = entry.parser_metadata.pop(
             RemoveEnclosingMiddleware.metadata_key(), None
@@ -186,7 +186,7 @@ class AddEnclosingMiddleware(BlockMiddleware):
         return entry
 
     # docstr-coverage: inherited
-    def transform_string(self, string: String, *args, **kwargs) -> String:
+    def transform_string(self, string: String, library: Library) -> String:
         metadata_key = RemoveEnclosingMiddleware.metadata_key()
         string.value = self._enclose(
             string.value,

--- a/bibtexparser/middlewares/latex_encoding.py
+++ b/bibtexparser/middlewares/latex_encoding.py
@@ -143,7 +143,8 @@ class LatexEncodingMiddleware(_PyStringTransformerMiddleware):
         self._encoder = encoder
 
     # docstr-coverage: inherited
-    def metadata_key(self) -> str:
+    @classmethod
+    def metadata_key(cls) -> str:
         return "latex_encoding"
 
     # docstr-coverage: inherited
@@ -210,7 +211,8 @@ class LatexDecodingMiddleware(_PyStringTransformerMiddleware):
         self._decoder = decoder
 
     # docstr-coverage: inherited
-    def metadata_key(self) -> str:
+    @classmethod
+    def metadata_key(cls) -> str:
         return "latex_decoding"
 
     # docstr-coverage: inherited

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -11,6 +11,7 @@ from typing import Literal
 from typing import Tuple
 from typing import Union
 
+from bibtexparser.library import Library
 from bibtexparser.model import Block
 from bibtexparser.model import Entry
 from bibtexparser.model import Field
@@ -54,7 +55,7 @@ class _NameTransformerMiddleware(BlockMiddleware, abc.ABC):
         raise NotImplementedError("called abstract method")
 
     # docstr-coverage: inherited
-    def transform_entry(self, entry: Entry, *args, **kwargs) -> Block:
+    def transform_entry(self, entry: Entry, library: Library) -> Block:
         field: Field
         try:
             for field in entry.fields:


### PR DESCRIPTION
- `transform_entry`/`transform_string` used `*args, **kwargs` instead of the base signature `(self, block, library)` in `AddEnclosingMiddleware` and `_NameTransformerMiddleware`
- `metadata_key` was overridden as an instance method in the Latex middlewares although the base declares a classmethod

Fixes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)