### PR TITLE
📦 Fix PyPI topic classifier, add Python 3.13/3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Text Processing :: Markup :: LaTeX",
     "Operating System :: OS Independent",
 ]
 dependencies = ["pylatexenc~=2.10"]


### PR DESCRIPTION
- "Topic :: Scientific/Engineering :: Artificial Intelligence" → "Topic :: Text Processing :: Markup :: LaTeX"
- add 3.13/3.14 version classifiers

The Beta development-status classifier is intentionally kept until the stable release.

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)