### PR TITLE
⬆️ Require Python 3.10+, test through 3.14

### DIFF
--- a/.github/workflows/linting_and_unittests.yml
+++ b/.github/workflows/linting_and_unittests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [{name = "Michael Weiss and other contributors", email = "code@mweiss.
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -22,7 +21,7 @@ license-files = ["LICENSE"]
 maintainers = [{name = "Michael Weiss", email = "code@mweiss.ch"}]
 name = "bibtexparser"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 docs = ["sphinx"]


### PR DESCRIPTION
`requires-python` claimed `>=3.9` while CI only tested 3.10-3.12, and 3.13/3.14 were untested entirely.

- bump `requires-python` to `>=3.10` (3.9 is past EOL and was not tested)
- drop the 3.9 classifier
- extend the CI matrix to 3.10-3.14

Note: should be merged before #556, which adds the 3.13/3.14 classifiers this matrix now backs (expect a trivial classifier-list conflict between the two — both touch adjacent lines in pyproject.toml).

Fixes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)