### PR TITLE
🐛 Resolve @string references case-insensitively

### DIFF
--- a/bibtexparser/middlewares/interpolate.py
+++ b/bibtexparser/middlewares/interpolate.py
@@ -38,6 +38,9 @@ class ResolveStringReferencesMiddleware(LibraryMiddleware):
         if not self.allow_inplace_modification:
             library = deepcopy(library)
 
+        # BibTeX string keys are case-insensitive; later definitions win.
+        string_values = {key.lower(): s.value for key, s in library.strings_dict.items()}
+
         entry: Entry
         raised_enclosing_warning = False
         for entry in library.entries:
@@ -58,9 +61,10 @@ class ResolveStringReferencesMiddleware(LibraryMiddleware):
             for field in entry.fields:
                 if _value_is_nonstring_or_enclosed(field.value):
                     continue
-                if field.value not in library.strings_dict:
+                try:
+                    field.value = string_values[field.value.lower()]
+                except KeyError:
                     continue
-                field.value = library.strings_dict[field.value].value
                 resolved_fields.append(field.key)
 
             if resolved_fields:

--- a/tests/middleware_tests/test_interpolate.py
+++ b/tests/middleware_tests/test_interpolate.py
@@ -35,6 +35,26 @@ def test_string_interpolation_middleware_interpolates_string():
     )
 
 
+def test_string_interpolation_is_case_insensitive():
+    bibtex = """
+    @string{lowercase = "Lower Case Note."}
+    @string{UPPERCASE = "Upper Case Note."}
+
+    @article{test_article,
+      note    = LOWERCASE,
+      comment = uppercase
+    }
+    """
+    library = Splitter(bibtex).split()
+
+    m = ResolveStringReferencesMiddleware()
+    library = m.transform(library)
+
+    fields = library.entries_dict["test_article"].fields_dict
+    assert fields["note"].value == '"Lower Case Note."'
+    assert fields["comment"].value == '"Upper Case Note."'
+
+
 def test_warning_is_raised_if_enclosings_are_removed():
     original_lib = Splitter(bibtex_string).split()
     m = RemoveEnclosingMiddleware(allow_inplace_modification=False)


### PR DESCRIPTION
Fixes #541

BibTeX downcases macro names when reading them, so `@string` keys are case-insensitive (e.g. `month = JAN` resolves against the style-defined `jan`). `ResolveStringReferencesMiddleware` did an exact, case-sensitive lookup in `library.strings_dict`, so such references were silently left unresolved.

### Changes
- Build a casefolded `{key.lower(): value}` lookup once per `transform` and match field values via `field.value.lower()`. Side benefit: avoids calling `strings_dict` (which copies the dict) up to twice per field.
- If two `@string` blocks differ only in case, the later definition wins, matching BibTeX redefinition semantics.
- Added a test covering both directions (uppercase reference to lowercase definition and vice versa).

### Out of scope
`Library` duplicate-key detection still compares string keys case-sensitively (`@string{jan=...}` + `@string{JAN=...}` is not flagged). That changes public `Library` behavior and deserves its own discussion/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)