### PR TITLE
🐛 Make Entry dict access symmetric for ENTRYTYPE and ID

### DIFF
--- a/bibtexparser/model.py
+++ b/bibtexparser/model.py
@@ -378,7 +378,12 @@ class Entry(Block):
         return self.fields_dict.get(key, default)
 
     def __contains__(self, key: str) -> bool:
-        """Dict-mimicking ``in`` operator."""
+        """Dict-mimicking ``in`` operator.
+
+        As in ``__getitem__``, ``ENTRYTYPE`` and ``ID`` are always contained.
+        """
+        if key in ("ENTRYTYPE", "ID"):
+            return True
         return key in self.fields_dict
 
     def __getitem__(self, key: str) -> Any:
@@ -400,8 +405,16 @@ class Entry(Block):
 
         This serves for partial v1.x backwards compatibility,
         as well as for a shorthand for `set_field`.
+
+        Mirroring ``__getitem__``, the keys ``ENTRYTYPE`` and ``ID``
+        set ``entry_type`` and ``key`` instead of a field.
         """
-        self.set_field(Field(key, value))
+        if key == "ENTRYTYPE":
+            self.entry_type = value
+        elif key == "ID":
+            self.key = value
+        else:
+            self.set_field(Field(key, value))
 
     def __delitem__(self, key: str) -> None:
         """Dict-mimicking index.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -96,6 +96,30 @@ def test_entry_contains():
     entry = Entry("article", "key", [Field("field", "value", 1)], 1, "raw")
     assert "field" in entry
     assert "other" not in entry
+    # ENTRYTYPE and ID are exposed by `__getitem__`, hence always contained
+    assert "ENTRYTYPE" in entry
+    assert "ID" in entry
+
+
+def test_entry_setitem_field():
+    entry = Entry("article", "key", [Field("field", "value", 1)], 1, "raw")
+    entry["field"] = "new_value"
+    entry["other"] = "other_value"
+    assert entry["field"] == "new_value"
+    assert entry["other"] == "other_value"
+    assert [f.key for f in entry.fields] == ["field", "other"]
+
+
+def test_entry_setitem_entrytype_and_id():
+    entry = Entry("article", "key", [Field("field", "value", 1)], 1, "raw")
+    entry["ENTRYTYPE"] = "book"
+    entry["ID"] = "new_key"
+    assert entry.entry_type == "book"
+    assert entry.key == "new_key"
+    assert entry["ENTRYTYPE"] == "book"
+    assert entry["ID"] == "new_key"
+    # No literal fields must be created for these keys
+    assert [f.key for f in entry.fields] == ["field"]
 
 
 def test_string_equality():


### PR DESCRIPTION
Fixes #532

`entry[ENTRYTYPE]` / `entry[ID]` return `entry_type` / `key`, but the corresponding assignment created a literal `Field(ENTRYTYPE, ...)`. The bogus field was shadowed by `__getitem__` on read (so `e[ENTRYTYPE] = book; e[ENTRYTYPE]` still returned `article`) and serialized as a regular `ENTRYTYPE = book` line on write. Particularly dangerous for v1 migrators, where assigning these dict keys was the documented way to change an entry type or key.

### Changes
- `__setitem__` mirrors `__getitem__`: `ENTRYTYPE` and `ID` set `entry_type` / `key` instead of creating a field. Mirroring (rather than raising) was chosen because these dunders exist precisely for v1 compatibility, and mirroring restores the dict invariant `e[k] = v ⟹ e[k] == v` with exactly the v1 semantics.
- `__contains__` had the same asymmetry (`ENTRYTYPE in entry` was `False` although `entry[ENTRYTYPE]` succeeds and `items()` lists it); it now returns `True` for the two magic keys.
- Deliberately untouched: `get()`/`pop()` (they return `Field` objects, and there is no sensible `Field` for the entry type) and `__delitem__` (deleting the entry type is nonsensical; it keeps harmlessly no-op-ing).

A literal field named `ENTRYTYPE`/`ID` can still be created via `set_field()` / `fields` if anyone genuinely needs that; only the dict-mimicking shorthand routes to the properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)