### PR TITLE
🏷️ Fix type annotations on public API

### DIFF
--- a/bibtexparser/entrypoint.py
+++ b/bibtexparser/entrypoint.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import TextIO
+from typing import Tuple
 from typing import Union
 
 from .library import Library
@@ -80,7 +81,7 @@ def _handle_deprecated_write_params(
     prepend_middleware: Optional[Iterable[Middleware]],
     kwargs: dict,
     function_name: str,
-) -> tuple[Optional[Iterable[Middleware]], Optional[Iterable[Middleware]]]:
+) -> Tuple[Optional[Iterable[Middleware]], Optional[Iterable[Middleware]]]:
     """Handle deprecated parameter names for write functions.
 
     :param unparse_stack: Current unparse_stack value
@@ -126,7 +127,7 @@ def parse_string(
     parse_stack: Optional[Iterable[Middleware]] = None,
     append_middleware: Optional[Iterable[Middleware]] = None,
     library: Optional[Library] = None,
-):
+) -> Library:
     """Parse a BibTeX string.
 
     :param bibtex_str: BibTeX string to parse

--- a/bibtexparser/middlewares/latex_encoding.py
+++ b/bibtexparser/middlewares/latex_encoding.py
@@ -90,8 +90,8 @@ class LatexEncodingMiddleware(_PyStringTransformerMiddleware):
 
     def __init__(
         self,
-        keep_math: bool = None,
-        enclose_urls: bool = None,
+        keep_math: Optional[bool] = None,
+        enclose_urls: Optional[bool] = None,
         encoder: Optional[UnicodeToLatexEncoder] = None,
         allow_inplace_modification: bool = True,
     ):
@@ -161,8 +161,8 @@ class LatexDecodingMiddleware(_PyStringTransformerMiddleware):
     def __init__(
         self,
         allow_inplace_modification: bool = True,
-        keep_braced_groups: bool = None,
-        keep_math_mode: bool = None,
+        keep_braced_groups: Optional[bool] = None,
+        keep_math_mode: Optional[bool] = None,
         decoder: Optional[LatexNodes2Text] = None,
     ):
         super().__init__(

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -37,7 +37,7 @@ class _NameTransformerMiddleware(BlockMiddleware, abc.ABC):
     def __init__(
         self,
         allow_inplace_modification: bool = True,
-        name_fields: Tuple[str] = ("author", "editor", "translator"),
+        name_fields: Tuple[str, ...] = ("author", "editor", "translator"),
     ):
         super().__init__(
             allow_inplace_modification=allow_inplace_modification,
@@ -46,7 +46,7 @@ class _NameTransformerMiddleware(BlockMiddleware, abc.ABC):
         self._name_fields = name_fields
 
     @property
-    def name_fields(self) -> Tuple[str]:
+    def name_fields(self) -> Tuple[str, ...]:
         """The fields that contain names, considered by this middleware."""
         return self._name_fields
 
@@ -187,7 +187,7 @@ class MergeNameParts(_NameTransformerMiddleware):
         self,
         style: Literal["last", "first"] = "last",
         allow_inplace_modification: bool = True,
-        name_fields: Tuple[str] = ("author", "editor", "translator"),
+        name_fields: Tuple[str, ...] = ("author", "editor", "translator"),
     ):
         self.style = style
         super().__init__(allow_inplace_modification, name_fields)


### PR DESCRIPTION
## Summary

The package ships `py.typed`, so these incorrect annotations are user-facing:

- `names.py`: `name_fields: Tuple[str]` (a 1-tuple type) → `Tuple[str, ...]` in both middleware constructors and the `name_fields` property.
- `latex_encoding.py`: `keep_math`, `enclose_urls`, `keep_braced_groups`, `keep_math_mode` declared `bool = None` → `Optional[bool] = None`.
- `entrypoint.py`: `parse_string` now annotated `-> Library`; lowercase `tuple[...]` aligned to the `typing.Tuple` style used everywhere else.

No runtime behavior change. Adding mypy/pyright to CI (which would have caught #529) is left as a possible follow-up.

Fixes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)