### PR TITLE
Honor custom parsing failure comments

### DIFF
--- a/bibtexparser/writer.py
+++ b/bibtexparser/writer.py
@@ -64,7 +64,7 @@ def _treat_failed_block(block: ParsingFailedBlock, bibtex_format: "BibtexFormat"
     if block.raw is None:
         raise ValueError(_failed_blocks_without_raw_error([block]))
     lines = len(block.raw.splitlines())
-    parsing_failed_comment = PARSING_FAILED_COMMENT.format(n=lines)
+    parsing_failed_comment = bibtex_format.parsing_failed_comment.format(n=lines)
     return [parsing_failed_comment, "\n", block.raw, "\n"]
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -172,11 +172,16 @@ def test_write_failed_block():
     lines = string.splitlines()
 
     assert len(lines) == 5
-    assert lines[0].startswith("% WARNING")
+    assert lines[0] == "% WARNING Parsing failed for the following 4 lines."
     assert lines[1] == "@article{irrelevant-for-this-test,"
     assert lines[2] == "except = {that-there-need-to-be},"
     assert lines[3] == "other = {multiple-lines}"
     assert lines[4] == "}"
+
+    bib_format = BibtexFormat()
+    bib_format.parsing_failed_comment = "% CUSTOM {n} lines"
+    custom_string = writer.write(library, bib_format)
+    assert custom_string.splitlines()[0] == "% CUSTOM 4 lines"
 
 
 def test_write_failed_block_without_raw_raises():


### PR DESCRIPTION
## Summary

- Honor the active `BibtexFormat.parsing_failed_comment` template when writing failed blocks.
- Strengthen the existing regression test for both the default and a custom template.

Fixes #530

## Validation

Preserved exact-SHA evidence for this unchanged upstream base and identical patch:
- `pytest tests/test_writer.py::test_write_failed_block`: 1 passed
- `pytest tests/test_writer.py`: 25 passed
- configured pre-commit hooks on both changed files: passed

The current no-install checkout lacks `pylatexenc`, so its fresh focused rerun stopped during collection. No dependencies or dependency files were changed.

## AI assistance

This Draft PR was prepared with OpenAI Codex. Automated root-cause analysis, patching, and validation evidence were used; no human self-review is claimed. It remains a draft for maintainer and user review.