### PR TITLE
Preserve iterable middleware arguments

### DIFF
--- a/bibtexparser/entrypoint.py
+++ b/bibtexparser/entrypoint.py
@@ -31,6 +31,7 @@ def _build_parse_stack(
     if append_middleware is None:
         return list(parse_stack)
 
+    append_middleware = list(append_middleware)
     parse_stack_types = [type(m) for m in parse_stack]
     append_stack_types = {type(m) for m in append_middleware}
     stack_types_intersect = set(parse_stack_types).intersection(append_stack_types)
@@ -61,13 +62,14 @@ def _build_unparse_stack(
     if prepend_middleware is None:
         return list(unparse_stack)
 
-    parse_stack_types = [type(m) for m in unparse_stack]
-    append_stack_types = {type(m) for m in prepend_middleware}
-    stack_types_intersect = set(parse_stack_types).intersection(append_stack_types)
+    prepend_middleware = list(prepend_middleware)
+    unparse_stack_types = [type(m) for m in unparse_stack]
+    prepend_stack_types = {type(m) for m in prepend_middleware}
+    stack_types_intersect = set(unparse_stack_types).intersection(prepend_stack_types)
     if len(stack_types_intersect) > 0:
         warnings.warn(
-            "Some middleware passed in append_middleware are "
-            f"already in the default parse_stack ({stack_types_intersect})."
+            "Some middleware passed in prepend_middleware are "
+            f"already in the default unparse_stack ({stack_types_intersect})."
         )
 
     return list(prepend_middleware) + list(unparse_stack)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -7,11 +7,47 @@ import warnings
 import pytest
 
 from bibtexparser import parse_file
+from bibtexparser import parse_string
 from bibtexparser import write_file
 from bibtexparser import write_string
 from bibtexparser.library import Library
+from bibtexparser.middlewares import NormalizeFieldKeys
+from bibtexparser.middlewares import SortFieldsCustomMiddleware
 from bibtexparser.model import Entry
 from bibtexparser.model import Field
+
+
+def test_parse_string_applies_append_middleware_from_iterator():
+    """One-shot middleware iterables must not be exhausted while checking duplicates."""
+    middleware = iter([NormalizeFieldKeys()])
+
+    library = parse_string(
+        "@article{test, TITLE = {Iterator middleware}}",
+        append_middleware=middleware,
+    )
+
+    assert library.entries[0].fields[0].key == "title"
+
+
+def test_write_string_applies_prepend_middleware_from_iterator():
+    """One-shot unparse middleware iterables must execute before the default stack."""
+    library = Library(
+        [
+            Entry(
+                entry_type="article",
+                key="test",
+                fields=[
+                    Field(key="title", value="Iterator middleware"),
+                    Field(key="year", value="2026"),
+                ],
+            )
+        ]
+    )
+    middleware = iter([SortFieldsCustomMiddleware(order=("year", "title"))])
+
+    written = write_string(library, prepend_middleware=middleware)
+
+    assert written.index("\tyear") < written.index("\ttitle")
 
 
 def test_gbk():


### PR DESCRIPTION
## Summary

* Materialize one-shot `append_middleware` and `prepend_middleware` iterables
  before checking their types.
* Ensure those middleware objects still execute after duplicate detection.
* Correct the unparse-stack duplicate warning to name the unparse parameters.

Fixes #531.

## Validation

* Focused iterator regressions under warnings-as-errors: 2 passed.
* Complete upstream suite: 2,578 passed, 12 skipped, with the four existing
  deprecation warnings in `tests/test_entrypoint.py`.
* `git diff --check`: passed.
* The project pre-commit executable was not available in the isolated local
  environment; GitHub CI should independently run the configured hooks.

## Review note

This change was developed and validated in a concentrated session rather than
exercised over a long period in production. It has focused public-API regression
coverage, but careful human review of the implementation and assumptions is
requested.

## AI assistance

This pull request was prepared with ChatGPT Codex using GPT-5.6 Sol with high
reasoning effort. Codex assisted with analysis, implementation, branch
isolation, and test execution. Automated validation is not a substitute for
maintainer review.
