### PR TITLE
Report unsupported parenthesis-delimited blocks

### DIFF
--- a/bibtexparser/splitter.py
+++ b/bibtexparser/splitter.py
@@ -66,6 +66,82 @@ class Splitter:
         # Start of string counts as line start
         return True
 
+    def _find_parenthesis_block_end(self, opening_parenthesis_index: int) -> int:
+        """Find the recoverable end of an unsupported parenthesis-delimited block.
+
+        Parentheses inside braces or quotes are field content. If the outer
+        parenthesis is unclosed, a new block at the start of a line is used as
+        the recovery boundary so subsequent supported blocks can still parse.
+        """
+        parenthesis_depth = 0
+        brace_depth = 0
+        in_quote = False
+
+        for index in range(opening_parenthesis_index, len(self.bibstr)):
+            char = self.bibstr[index]
+            escaped = index > 0 and self.bibstr[index - 1] == "\\"
+
+            if (
+                index > opening_parenthesis_index
+                and char == "@"
+                and parenthesis_depth == 1
+                and brace_depth == 0
+                and not in_quote
+                and self._is_at_line_start(index)
+            ):
+                return index
+
+            if escaped:
+                continue
+            if char == '"' and brace_depth == 0:
+                in_quote = not in_quote
+            elif in_quote:
+                continue
+            elif char == "{":
+                brace_depth += 1
+            elif char == "}" and brace_depth > 0:
+                brace_depth -= 1
+            elif brace_depth == 0 and char == "(":
+                parenthesis_depth += 1
+            elif brace_depth == 0 and char == ")":
+                parenthesis_depth -= 1
+                if parenthesis_depth == 0:
+                    return index + 1
+
+        return len(self.bibstr)
+
+    def _skip_marks_before(self, end_index: int) -> None:
+        """Advance the mark iterator to the first mark at or after ``end_index``."""
+        while True:
+            mark = self._next_mark(accept_eof=True)
+            if mark is None:
+                break
+            if mark.start() >= end_index:
+                self._unaccepted_mark = mark
+                break
+
+        # The normal block handlers leave this index at their closing delimiter.
+        # Mirror that state so the next implicit-comment boundary starts correctly.
+        self._current_char_index = end_index - 1
+
+    def _handle_parenthesis_block(self, mark: re.Match) -> ParsingFailedBlock:
+        """Return an explicit failure for an unsupported parenthesis-delimited block."""
+        start_line = self._current_line
+        end_index = self._find_parenthesis_block_end(mark.end())
+        raw = self.bibstr[mark.start() : end_index].rstrip()
+        self._skip_marks_before(end_index)
+        return ParsingFailedBlock(
+            start_line=start_line,
+            raw=raw,
+            error=BlockAbortedException(
+                abort_reason=(
+                    "Parenthesis-delimited blocks are not supported. "
+                    "Use curly braces or handle this failed block explicitly."
+                ),
+                end_index=end_index,
+            ),
+        )
+
     def _end_implicit_comment(self, end_char_index) -> ImplicitComment | None:
         if self._implicit_comment_start is None:
             return  # No implicit comment started
@@ -284,7 +360,7 @@ class Splitter:
             The library with the added blocks.
         """
         self._markiter = re.finditer(
-            r"(?<!\\)[\{\}\",=\n]|@[\w]*( |\t)*(?={)", self.bibstr, re.MULTILINE
+            r"(?<!\\)[\{\}\",=\n]|@[\w]*( |\t)*(?=[{(])", self.bibstr, re.MULTILINE
         )
 
         if library is None:
@@ -309,7 +385,9 @@ class Splitter:
                 start_line = self._current_line
                 try:
                     # Start new block parsing
-                    if m_val.startswith("@comment"):
+                    if self.bibstr[m.end()] == "(":
+                        library.add(self._handle_parenthesis_block(m))
+                    elif m_val.startswith("@comment"):
                         library.add(self._handle_explicit_comment())
                     elif m_val.startswith("@preamble"):
                         library.add(self._handle_preamble())

--- a/tests/splitter_tests/test_splitter_block_start_detection.py
+++ b/tests/splitter_tests/test_splitter_block_start_detection.py
@@ -154,6 +154,55 @@ def test_mixed_blocks_same_line(
     assert len(library.comments) == expected_comments
 
 
+@pytest.mark.parametrize(
+    "unsupported_block",
+    [
+        pytest.param(
+            "@article(test, title = {A (parenthesized) title})",
+            id="entry",
+        ),
+        pytest.param(
+            '@string(name = "value (draft)")',
+            id="string",
+        ),
+        pytest.param(
+            '@preamble("value (draft)")',
+            id="preamble",
+        ),
+        pytest.param(
+            "@comment(text (with nested parentheses))",
+            id="comment",
+        ),
+    ],
+)
+@pytest.mark.parametrize("same_line", [False, True], ids=["next-line", "same-line"])
+def test_parenthesis_delimited_block_is_explicit_failure(unsupported_block: str, same_line: bool):
+    """Unsupported standard syntax must never disappear into an implicit comment."""
+    separator = " " if same_line else "\n"
+    library = Splitter(
+        f"{unsupported_block}{separator}@book{{valid, title = {{Supported block}}}}"
+    ).split()
+
+    assert len(library.failed_blocks) == 1
+    assert library.failed_blocks[0].raw == unsupported_block
+    assert "Parenthesis-delimited blocks are not supported" in (
+        library.failed_blocks[0].error.abort_reason
+    )
+    assert len(library.comments) == 0
+    assert [entry.key for entry in library.entries] == ["valid"]
+
+
+def test_unclosed_parenthesis_block_recovers_at_next_line_block():
+    """An unclosed unsupported block does not hide a later supported block."""
+    library = Splitter(dedent("""\
+            @article(broken, title = {Unclosed parenthesis block}
+            @book{valid, title = {Supported block}}""")).split()
+
+    assert len(library.failed_blocks) == 1
+    assert library.failed_blocks[0].raw == ("@article(broken, title = {Unclosed parenthesis block}")
+    assert [entry.key for entry in library.entries] == ["valid"]
+
+
 # =============================================================================
 # Test: Error recovery when new block starts at line start
 # =============================================================================


### PR DESCRIPTION
## Summary

* Detect standard parenthesis-delimited entries, strings, preambles, and
  comments instead of classifying them as implicit comments.
* Retain their exact source in explicit `ParsingFailedBlock` objects while full
  parenthesis parsing remains unsupported.
* Recover later supported blocks on the same or following line, including after
  an unclosed parenthesis block.

Fixes #533 by taking the issue's fail-closed interim option. This does not claim
to implement full parenthesis-delimited parsing.

## Validation

* Focused splitter detection and recovery suite under warnings-as-errors: 32
  passed.
* Complete upstream suite: 2,585 passed, 12 skipped, with the four existing
  deprecation warnings in `tests/test_entrypoint.py`.
* `git diff --check`: passed.
* The project pre-commit executable was not available in the isolated local
  environment; GitHub CI should independently run the configured hooks.

## Review note

This change was developed and validated in a concentrated session rather than
exercised over a long period in production. The recovery scanner handles nested
parentheses, braces, quotes, and subsequent blocks, but careful human review of
malformed-input edge cases is particularly important.

## AI assistance

This pull request was prepared with ChatGPT Codex using GPT-5.6 Sol with high
reasoning effort. Codex assisted with analysis, implementation, branch
isolation, and test execution. Automated validation is not a substitute for
maintainer review.
