### PR TITLE
Preserve trailing backslashes in name round trips

### DIFF
--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -143,8 +143,14 @@ class NameParts:
         last = " ".join(self.last) if self.last else None
         jr = " ".join(self.jr) if self.jr else None
 
-        von_last = " ".join(name for name in [von, last] if name)
-        return ", ".join(escape_last_slash(name) for name in [von_last, jr, first] if name)
+        sections = [
+            name for name in [" ".join(name for name in [von, last] if name), jr, first] if name
+        ]
+
+        # Only sections followed by a comma need protection from a trailing backslash.
+        # Escaping the final section changes its value even though no delimiter follows it.
+        escaped_sections = [escape_last_slash(section) for section in sections[:-1]]
+        return ", ".join([*escaped_sections, sections[-1]])
 
 
 class SplitNameParts(_NameTransformerMiddleware):
@@ -311,6 +317,7 @@ def parse_single_name_into_parts(name: str, strict: bool = True) -> NameParts:
             # If we're at the end of the string, then the \ is just a \.
             except StopIteration:
                 word.append(char)
+                continue
 
         # Start of a braced expression.
         if char == "{":

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -875,25 +875,7 @@ def test_split_name_into_parts(name, expected_as_dict, strict):
 def test_merge_last_name_first_inverse(name, expected_as_dict, strict):
     """Tests that merging name parts using the last-name-first method
     maintains the "semantics" of the name.
-
-    This property does not hold for certain values that contain '\\'.
     """
-
-    # cases where either the last name or "von" part ends with an odd number of `\` cannot be handled,
-    # since in those cases the `,` is escaped when the name parts are put back together
-    def ends_with_odd_slash(names: list[str]) -> bool:
-        if len(names) == 0:
-            return False
-        name = names[-1]
-        count = 0
-        i = len(name) - 1
-        while i >= 0 and name[i] == "\\":
-            count += 1
-            i -= 1
-        return count % 2 == 1
-
-    if any(ends_with_odd_slash(name) for name in expected_as_dict.values()):
-        pytest.skip("Inverse property does not hold for names ending with '\\'")
 
     nameparts = _dict_to_nameparts(expected_as_dict)
     merged = nameparts.merge_last_name_first


### PR DESCRIPTION
## Summary

* Stop processing a terminal backslash twice after the name parser reaches end
  of input.
* Escape only last-name-first sections that are followed by a comma.
* Enable the existing strict and non-strict inverse-property cases instead of
  skipping names with odd trailing backslashes.

Fixes #567.

## Validation

* Complete name middleware suite under warnings-as-errors: 689 passed.
* Complete upstream suite: 2,578 passed, 10 skipped, with the four existing
  deprecation warnings in `tests/test_entrypoint.py`. The two removed skips are
  the now-passing strict and non-strict inverse cases.
* `git diff --check`: passed.
* The project pre-commit executable was not available in the isolated local
  environment; GitHub CI should independently run the configured hooks.

## Review note

This change was developed and validated in a concentrated session rather than
exercised over a long period in production. The broad existing name fixture
matrix now passes without the targeted skip, but careful human review of TeX
escaping semantics is requested.

## AI assistance

This pull request was prepared with ChatGPT Codex using GPT-5.6 Sol with high
reasoning effort. Codex assisted with analysis, implementation, branch
isolation, and test execution. Automated validation is not a substitute for
maintainer review.
