### PR TITLE
Require exact special command types

### DIFF
--- a/bibtexparser/splitter.py
+++ b/bibtexparser/splitter.py
@@ -300,6 +300,7 @@ class Splitter:
             m_val = m.group(0).lower()
 
             if m_val.startswith("@"):
+                block_type = m_val[1:].strip()
                 # Clean up previous block implicit_comment
                 implicit_comment = self._end_implicit_comment(m.start())
                 if implicit_comment is not None:
@@ -309,11 +310,11 @@ class Splitter:
                 start_line = self._current_line
                 try:
                     # Start new block parsing
-                    if m_val.startswith("@comment"):
+                    if block_type == "comment":
                         library.add(self._handle_explicit_comment())
-                    elif m_val.startswith("@preamble"):
+                    elif block_type == "preamble":
                         library.add(self._handle_preamble())
-                    elif m_val.startswith("@string"):
+                    elif block_type == "string":
                         library.add(self._handle_string(m), fail_on_duplicate_key=False)
                     else:
                         library.add(self._handle_entry(m, m_val), fail_on_duplicate_key=False)

--- a/tests/splitter_tests/test_splitter_block_start_detection.py
+++ b/tests/splitter_tests/test_splitter_block_start_detection.py
@@ -154,6 +154,25 @@ def test_mixed_blocks_same_line(
     assert len(library.comments) == expected_comments
 
 
+@pytest.mark.parametrize(
+    "entry_type",
+    [
+        pytest.param("commentary", id="comment-prefix"),
+        pytest.param("preamble_study", id="preamble-prefix"),
+        pytest.param("string_theory", id="string-prefix"),
+    ],
+)
+def test_entry_type_extending_special_command_name_is_entry(entry_type: str):
+    """Special commands require an exact type match; longer custom types remain entries."""
+    library = Splitter(f"@{entry_type}{{key, title = {{Custom entry type}}}}").split()
+
+    assert len(library.failed_blocks) == 0
+    assert len(library.comments) == 0
+    assert len(library.preambles) == 0
+    assert len(library.strings) == 0
+    assert [(entry.entry_type, entry.key) for entry in library.entries] == [(entry_type, "key")]
+
+
 # =============================================================================
 # Test: Error recovery when new block starts at line start
 # =============================================================================


### PR DESCRIPTION
## Summary

* Dispatch `comment`, `preamble`, and `string` as special commands only on an
  exact case-insensitive type match.
* Preserve longer custom types such as `commentary`, `preamble_study`, and
  `string_theory` as ordinary entries.

Fixes #568.

## Validation

* Focused custom-entry regression matrix under warnings-as-errors: 3 passed.
* Complete upstream suite: 2,579 passed, 12 skipped, with the four existing
  deprecation warnings in `tests/test_entrypoint.py`.
* `git diff --check`: passed.
* The project pre-commit executable was not available in the isolated local
  environment; GitHub CI should independently run the configured hooks.

## Review note

This change was developed and validated in a concentrated session rather than
exercised over a long period in production. Although the dispatch change is
small and covered across all three prefixes, careful human review is requested.

## AI assistance

This pull request was prepared with ChatGPT Codex using GPT-5.6 Sol with high
reasoning effort. Codex assisted with analysis, implementation, branch
isolation, and test execution. Automated validation is not a substitute for
maintainer review.
