### PR TITLE
Capture expected deprecation warnings in entry-point tests

### DIFF
--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -143,8 +143,9 @@ def test_write_file_both_parse_stack_and_unparse_stack_raises_error():
         temp_path = f.name
 
     try:
-        with pytest.raises(ValueError) as excinfo:
-            write_file(temp_path, library, parse_stack=[], unparse_stack=[])
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(ValueError) as excinfo:
+                write_file(temp_path, library, parse_stack=[], unparse_stack=[])
         assert "parse_stack" in str(excinfo.value)
         assert "unparse_stack" in str(excinfo.value)
         assert "Use 'unparse_stack' instead" in str(excinfo.value)
@@ -160,8 +161,9 @@ def test_write_file_both_append_and_prepend_middleware_raises_error():
         temp_path = f.name
 
     try:
-        with pytest.raises(ValueError) as excinfo:
-            write_file(temp_path, library, append_middleware=[], prepend_middleware=[])
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(ValueError) as excinfo:
+                write_file(temp_path, library, append_middleware=[], prepend_middleware=[])
         assert "append_middleware" in str(excinfo.value)
         assert "prepend_middleware" in str(excinfo.value)
         assert "Use 'prepend_middleware' instead" in str(excinfo.value)
@@ -215,8 +217,9 @@ def test_write_string_both_parse_stack_and_unparse_stack_raises_error():
     """Test that providing both parse_stack and unparse_stack raises ValueError."""
     library = Library([])
 
-    with pytest.raises(ValueError) as excinfo:
-        write_string(library, parse_stack=[], unparse_stack=[])
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError) as excinfo:
+            write_string(library, parse_stack=[], unparse_stack=[])
     assert "parse_stack" in str(excinfo.value)
     assert "unparse_stack" in str(excinfo.value)
     assert "Use 'unparse_stack' instead" in str(excinfo.value)
@@ -226,8 +229,9 @@ def test_write_string_both_append_and_prepend_middleware_raises_error():
     """Test that providing both append_middleware and prepend_middleware raises ValueError."""
     library = Library([])
 
-    with pytest.raises(ValueError) as excinfo:
-        write_string(library, append_middleware=[], prepend_middleware=[])
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError) as excinfo:
+            write_string(library, append_middleware=[], prepend_middleware=[])
     assert "append_middleware" in str(excinfo.value)
     assert "prepend_middleware" in str(excinfo.value)
     assert "Use 'prepend_middleware' instead" in str(excinfo.value)


### PR DESCRIPTION
## Summary

* Capture the expected `DeprecationWarning` in legacy/new parameter conflict tests.
* Retain the existing `ValueError` and message assertions.
* Make the complete suite pass with warnings treated as errors.

Closes #581.

## Validation

* `pytest -p no:cacheprovider -W error`: 2,576 passed, 12 skipped.
* Complete pre-commit hook suite: passed.

## Review note

This is a test-only change. It makes warnings already emitted by the intended conflict path explicit rather than suppressing warnings globally.

## AI assistance

This pull request was prepared with ChatGPT Codex using GPT-5.6 Sol with high reasoning effort. Codex assisted with warning analysis, branch isolation, and validation. Automated validation is not a substitute for maintainer review.
