### PR TITLE
Make string reference expansion opt-in

### DIFF
--- a/bibtexparser/middlewares/parsestack.py
+++ b/bibtexparser/middlewares/parsestack.py
@@ -1,4 +1,3 @@
-from bibtexparser.middlewares import ResolveStringReferencesMiddleware
 from bibtexparser.middlewares.enclosing import AddEnclosingMiddleware
 from bibtexparser.middlewares.enclosing import RemoveEnclosingMiddleware
 
@@ -8,7 +7,6 @@ from .middleware import Middleware
 def default_parse_stack(allow_inplace_modification: bool = True) -> list[Middleware]:
     """The default parse stack to be applied after splitting, if not specified otherwise."""
     return [
-        ResolveStringReferencesMiddleware(allow_inplace_modification=allow_inplace_modification),
         RemoveEnclosingMiddleware(allow_inplace_modification=allow_inplace_modification),
     ]
 

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -48,8 +48,21 @@ part of the expected functionality for most users.
 
 Currently, the default parse stack consists of the following layers:
 
-* :class:`bibtexparser.middlewares.ResolveStringReferencesMiddleware`: De-Reference reference to @string definitions.
 * :class:`bibtexparser.middlewares.RemoveEnclosingMiddleware`: Removes enclosing (e.g. curly braces or "") from values.
+
+String references are retained by default because replacing a reference with
+its current value destroys the relationship with its ``@string`` definition.
+Applications that intentionally want dereferenced values can select
+:class:`bibtexparser.middlewares.ResolveStringReferencesMiddleware` explicitly,
+before removing enclosures:
+
+.. code-block:: python
+
+    layers = [
+        m.ResolveStringReferencesMiddleware(),
+        m.RemoveEnclosingMiddleware(),
+    ]
+    library = bibtexparser.parse_file("bibtex.bib", parse_stack=layers)
 
 The default write stack consists of the following layers:
 

--- a/tests/middleware_tests/test_interpolate.py
+++ b/tests/middleware_tests/test_interpolate.py
@@ -1,5 +1,6 @@
 import pytest
 
+import bibtexparser
 from bibtexparser.middlewares.enclosing import RemoveEnclosingMiddleware
 from bibtexparser.middlewares.interpolate import ResolveStringReferencesMiddleware
 from bibtexparser.splitter import Splitter
@@ -16,6 +17,28 @@ bibtex_string = """
 }
 
 """
+
+
+def test_default_parse_retains_string_reference_linkage():
+    """Ordinary parse/write use must not replace a reusable macro with its current value."""
+    library = bibtexparser.parse_string(bibtex_string)
+
+    assert library.entries_dict["test_article"]["note"] == "test_note"
+    written = bibtexparser.write_string(library)
+    assert "note = test_note" in written
+
+
+def test_public_parse_can_expand_string_references_explicitly():
+    """Callers can request dereferencing before the enclosing representation changes."""
+    library = bibtexparser.parse_string(
+        bibtex_string,
+        parse_stack=[
+            ResolveStringReferencesMiddleware(),
+            RemoveEnclosingMiddleware(),
+        ],
+    )
+
+    assert library.entries_dict["test_article"]["note"] == "This is a test note."
 
 
 def test_string_interpolation_middleware_interpolates_string():


### PR DESCRIPTION
## Summary

* Retain references to `@string` definitions in the default parse stack.
* Keep `ResolveStringReferencesMiddleware` available as an explicit dereferencing choice.
* Document and test the required middleware order before enclosure removal.
* Protect macro linkage through the public parse/write entry points.

Closes #590.

## Validation

* `pytest -p no:cacheprovider -W error tests/middleware_tests/test_interpolate.py`: 5 passed.
* Complete upstream suite: 2,578 passed, 12 skipped, with the four existing deprecation warnings in `tests/test_entrypoint.py`.
* Complete pre-commit hook suite: passed.

## Review note

This is a user-visible default change: callers who rely on immediate literal values must add `ResolveStringReferencesMiddleware` explicitly. The reason for proposing it is that default expansion is irreversible during a write—macro linkage is semantic information, and the original reference cannot be reconstructed reliably from its expanded text.

The PR deliberately uses basic references and does not depend on the broader concatenation work discussed in #396.

## AI assistance

This pull request was prepared with ChatGPT Codex using GPT-5.6 Sol with high reasoning effort. Codex assisted with default-policy analysis, standalone test design, documentation, and validation. Automated validation is not a substitute for maintainer review.
