### PR TITLE
Tokenize backslash escapes by parity in the splitter

### DIFF
--- a/bibtexparser/splitter.py
+++ b/bibtexparser/splitter.py
@@ -283,8 +283,18 @@ class Splitter:
         Returns:
             The library with the added blocks.
         """
-        self._markiter = re.finditer(
-            r"(?<!\\)[\{\}\",=\n]|@[\w]*( |\t)*(?={)", self.bibstr, re.MULTILINE
+        # A backslash escapes the character right after it, so a backslash that is
+        # itself escaped cannot escape the next one. Matching the escape pairs and
+        # then dropping them gets that parity right, which a look-behind cannot.
+        # Newlines are not escapable: they are marks for line counting only.
+        self._markiter = (
+            m
+            for m in re.finditer(
+                r"\\[\\\{\}\",=]|[\{\}\",=\n]|@[\w]*( |\t)*(?={)",
+                self.bibstr,
+                re.MULTILINE,
+            )
+            if m.group(0)[0] != "\\"
         )
 
         if library is None:

--- a/tests/splitter_tests/test_splitter_backslash_parity.py
+++ b/tests/splitter_tests/test_splitter_backslash_parity.py
@@ -1,0 +1,144 @@
+"""Tests that the mark tokenizer treats backslash runs by parity.
+
+A backslash escapes the character right after it, so a backslash which is itself
+escaped cannot escape the next one. Only an odd-length run hides the delimiter
+behind it; an even-length run leaves it in force.
+"""
+
+import pytest as pytest
+
+import bibtexparser
+from bibtexparser.library import Library
+from bibtexparser.model import Entry
+from bibtexparser.model import Field
+from bibtexparser.splitter import Splitter
+
+BS = "\\"
+
+EVEN_RUNS = [0, 2, 4]
+ODD_RUNS = [1, 3]
+
+# Value shapes, each with a `%s` slot for the backslash run right before the
+# delimiter that ends (or is contained in) the value.
+CLOSED_VALUES = {"braced": "{v%s}", "quoted": '"v%s"'}
+OPEN_VALUES = {"bare": "v%s", "nested-group": "{a%s{b} c}"}
+ALL_VALUES = {**CLOSED_VALUES, **OPEN_VALUES}
+
+
+def _parse_entry(value: str) -> Library:
+    return Splitter("@article{key,\n    title = " + value + ",\n    year = {2024}\n}").split()
+
+
+@pytest.mark.parametrize("run", EVEN_RUNS)
+@pytest.mark.parametrize("template", ALL_VALUES.values(), ids=ALL_VALUES.keys())
+def test_even_backslash_run_leaves_delimiter_in_force(template: str, run: int):
+    value = template % (BS * run)
+    library = _parse_entry(value)
+
+    assert library.failed_blocks == []
+    fields = library.entries[0].fields_dict
+    assert set(fields) == {"title", "year"}
+    assert fields["title"].value == value
+    assert fields["year"].value == "{2024}"
+
+
+@pytest.mark.parametrize("run", ODD_RUNS)
+@pytest.mark.parametrize("template", CLOSED_VALUES.values(), ids=CLOSED_VALUES.keys())
+def test_odd_backslash_run_escapes_the_closing_enclosing(template: str, run: int):
+    """The value is never closed, so the block is reported as failed."""
+    library = _parse_entry(template % (BS * run))
+
+    assert len(library.failed_blocks) == 1
+    assert library.entries == []
+
+
+@pytest.mark.parametrize("run", ODD_RUNS)
+@pytest.mark.parametrize("template", OPEN_VALUES.values(), ids=OPEN_VALUES.keys())
+def test_odd_backslash_run_escapes_the_field_separator(template: str, run: int):
+    """The following comma is escaped, so the rest of the entry is part of the value."""
+    library = _parse_entry(template % (BS * run))
+
+    assert library.failed_blocks == []
+    assert set(library.entries[0].fields_dict) == {"title"}
+
+
+@pytest.mark.parametrize("run", EVEN_RUNS)
+def test_even_backslash_run_closes_string_block(run: int):
+    library = Splitter("@string{s = {v" + BS * run + "}}").split()
+
+    assert library.failed_blocks == []
+    assert library.strings[0].value == "{v" + BS * run + "}"
+
+
+@pytest.mark.parametrize("run", EVEN_RUNS)
+def test_even_backslash_run_closes_preamble_block(run: int):
+    library = Splitter("@preamble{{v" + BS * run + "}}").split()
+
+    assert library.failed_blocks == []
+    assert library.preambles[0].value == "{v" + BS * run + "}"
+
+
+@pytest.mark.parametrize("run", EVEN_RUNS)
+def test_even_backslash_run_closes_explicit_comment_block(run: int):
+    library = Splitter("@comment{c" + BS * run + "}\n@article{key, year = {2024}}").split()
+
+    assert library.failed_blocks == []
+    assert library.comments[0].comment == "c" + BS * run
+    assert library.entries[0].key == "key"
+
+
+@pytest.mark.parametrize("run", ODD_RUNS + EVEN_RUNS)
+def test_backslashes_at_end_of_line_do_not_shift_line_numbers(run: int):
+    """A LaTeX line break (`\\\\`) at the end of a line is not a line continuation."""
+    bibtex = (
+        "@article{first,\n"
+        "    abstract = {First line." + BS * run + "\n"
+        "                Second line.},\n"
+        "    year = {2024}\n"
+        "}\n"
+        "\n"
+        "@book{second,\n"
+        "    year = {1999}\n"
+        "}"
+    )
+
+    library = Splitter(bibtex).split()
+
+    assert [block.start_line for block in library.blocks] == [0, 6]
+    assert library.entries[0].fields_dict["year"].start_line == 3
+
+
+@pytest.mark.parametrize("run", EVEN_RUNS)
+def test_written_backslash_run_is_read_back_unchanged(run: int):
+    """The writer emits these values, so the splitter has to accept them again."""
+    value = "C:" + BS * run
+    library = Library()
+    library.add(Entry("article", "key", [Field("title", value), Field("year", "2024")]))
+
+    reparsed = bibtexparser.parse_string(bibtexparser.write_string(library))
+
+    assert reparsed.failed_blocks == []
+    assert reparsed.entries[0].fields_dict["title"].value == value
+    assert reparsed.entries[0].fields_dict["year"].value == "2024"
+
+
+def test_escaped_delimiter_in_an_entry_key_is_not_a_mark():
+    library = Splitter("@article{ke" + BS + "{y, title = {v}}").split()
+
+    assert library.failed_blocks == []
+    assert library.entries[0].key == "ke" + BS + "{y"
+    assert library.entries[0].fields_dict["title"].value == "{v}"
+
+
+def test_escaped_delimiter_in_a_field_key_is_not_a_mark():
+    library = Splitter("@article{key, ti" + BS + "=tle = {v}, year = {2024}}").split()
+
+    assert library.failed_blocks == []
+    assert set(library.entries[0].fields_dict) == {"ti" + BS + "=tle", "year"}
+
+
+def test_escaped_delimiter_in_a_string_key_is_not_a_mark():
+    library = Splitter("@string{s" + BS + "{x = {v}}").split()
+
+    assert library.failed_blocks == []
+    assert library.strings[0].key == "s" + BS + "{x"


### PR DESCRIPTION
`Splitter.split` finds the structural marks with

```python
re.finditer(r"(?<!\\)[\{\}\",=\n]|@[\w]*( |\t)*(?={)", self.bibstr, re.MULTILINE)
```

That look-behind is fixed width, so all it can ask is "is the previous character a backslash?" — it cannot ask whether *that* backslash is itself escaped. A delimiter sitting behind an even-length backslash run is treated as escaped when it is not, and the field scan runs past the end of the value.

```python
>>> bibtexparser.parse_string(r'@article{k, title = {C:\\}, year = {2024}}').failed_blocks
[<ParsingFailedBlock>]            # "Unexpectedly reached end of file"

>>> lib = bibtexparser.parse_string(r'@article{k, title = a\\, year = {2024}}')
>>> lib.entries[0].fields_dict.keys()
dict_keys(['title'])              # `year` swallowed, and `failed_blocks` is empty
```

The library also cannot read back what it writes: `write_string` on a field value of `C:\\` emits `title = {C:\\},`, and parsing that gives a failed block.

The escape model the rest of the package uses is already parity-based. `parse_single_name_into_parts` consumes the escaped character with `next(nameiter)`, and `NameParts.merge_last_name_first` counts the trailing backslashes explicitly ("Even number: everything is escaped"). Only the splitter's tokenizer disagrees.

## Extent

I went over the whole grid rather than the one case I hit: runs of 0-4 backslashes before `}`, `"`, `,` and `{`, in braced / quoted / bare / nested-group values, and in `@string`, `@preamble` and `@comment` blocks. Every even-length run of 2 or more is wrong, in every one of those contexts - 12 divergent rows. The bare-value and nested-group ones are the nasty ones: the entry parses, nothing lands in `failed_blocks`, and the fields after the value are simply gone. pybtex accepts all 12.

The same look-behind also covers `\n`, where escaping means nothing at all - newline marks exist only to advance the line counter, and BibTeX has no line continuation. So any line ending in a backslash, and `abstract = {First line.\\` is ordinary LaTeX, makes the counter skip a line and every `start_line` after it is off by one.

## Fix

Match the escape pairs and drop them instead of looking behind. Pairing left to right gives the parity for free: `\\` consumes both backslashes so the delimiter after them is a mark again, while `\\\}` consumes two and then escapes the brace. Newlines stay out of the escapable set.

Odd runs still escape the delimiter. That is this parser's deliberate divergence from BibTeX proper, which counts braces literally and has no escape in its scanner at all, and I have not touched it - the new tests pin it in both directions so it cannot be dropped by accident either.

## What this does not cover

A value with an *odd* trailing backslash still writes out as something this parser cannot read back: `title = {C:\},`, where the closing brace is escaped under the rule above. Fixing that means deciding whether the writer should brace-protect the value the way `escape_last_slash` does for names, which is a writer-side call I would rather not make on my own. Happy to follow up if you want it.

This is orthogonal to the other splitter work in the queue: #572 is brace-depth accounting inside `_move_to_comma_or_closing_curly_bracket`, #573 is `names.py`. I checked that the #452 abstract from #572 parses identically before and after this change.

One overlap worth flagging: my own #565 adds an `_is_escaped` helper to the middleware layer that deliberately mirrors the splitter's current single-backslash rule. Whichever of the two lands second should bring that helper along to parity so the layers do not disagree - I will do that on the other branch.

## Validation

- New `tests/splitter_tests/test_splitter_backslash_parity.py`, 40 cases, 20 of which fail on `main`.
- Full suite 2616 passed / 12 skipped, up from 2576 / 12; no existing test changed.
- I mutated the new logic six ways - revert to the look-behind, drop escaping entirely, drop the backslash from the escapable set, make newlines escapable, keep the consumed pairs as marks, invert the filter - and every one is caught. A semantics-preserving reordering of the alternation is not caught, which is the control.
- black / isort / flake8 / pyupgrade at the pinned `.pre-commit-config.yaml` revisions.

---
*This pull request was prepared with the assistance of AI, under my direction and review.*
