### PR TITLE
:bug: Make InvalidNameError copyable and picklable

### DIFF
--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -27,9 +27,6 @@ class InvalidNameError(ValueError):
         super().__init__(message)
 
     def __reduce__(self):
-        # Rebuild from name and reason so the exception stays copyable and
-        # picklable; the base ValueError stores only the formatted message in
-        # args, which does not match this two-argument __init__.
         return (self.__class__, (self.name, self.reason))
 
 

--- a/bibtexparser/middlewares/names.py
+++ b/bibtexparser/middlewares/names.py
@@ -21,8 +21,16 @@ class InvalidNameError(ValueError):
     """Exception raised by :py:func:`parse_single_name_into_parts` when facing an invalid name."""
 
     def __init__(self, name: str, reason: str):
+        self.name = name
+        self.reason = reason
         message: str = f"Cannot split the following name `{name}` into parts: {reason}"
         super().__init__(message)
+
+    def __reduce__(self):
+        # Rebuild from name and reason so the exception stays copyable and
+        # picklable; the base ValueError stores only the formatted message in
+        # args, which does not match this two-argument __init__.
+        return (self.__class__, (self.name, self.reason))
 
 
 class _NameTransformerMiddleware(BlockMiddleware, abc.ABC):

--- a/tests/middleware_tests/test_names.py
+++ b/tests/middleware_tests/test_names.py
@@ -132,6 +132,24 @@ def test_name_splitting_strict_mode(name: str, reason: str):
         parse_single_name_into_parts(name, strict=True)
 
 
+def test_invalid_name_error_is_copyable():
+    # A MiddlewareErrorBlock stores the InvalidNameError, and later middlewares
+    # (for example SortBlocksByTypeAndKeyMiddleware) deepcopy the library, so
+    # the exception has to survive copy and pickle. It could not before: its
+    # two-argument __init__ did not match the single message stored in args.
+    import pickle
+
+    with pytest.raises(InvalidNameError) as exc_info:
+        parse_single_name_into_parts("AA, BB, CC, DD", strict=True)
+    error = exc_info.value
+
+    for clone in (deepcopy(error), pickle.loads(pickle.dumps(error))):
+        assert isinstance(clone, InvalidNameError)
+        assert str(clone) == str(error)
+        assert clone.name == error.name
+        assert clone.reason == error.reason
+
+
 def _dict_to_nameparts(as_dict):
     return NameParts(
         first=as_dict["first"],


### PR DESCRIPTION
`InvalidNameError` can't be copied or pickled, which crashes normal parsing:

```python
import copy
from bibtexparser.middlewares.names import InvalidNameError
copy.deepcopy(InvalidNameError(name="Doe, John", reason="Too many commas"))
# TypeError: InvalidNameError.__init__() missing 1 required positional argument
```

Its `__init__` takes `name` and `reason` but the base `ValueError` only keeps the formatted message in `args`, so deepcopy/pickle rebuild it with a single argument. This surfaces through the public API: a failed name is stored in a `MiddlewareErrorBlock`, and a later middleware like `SortBlocksByTypeAndKeyMiddleware` deepcopies the whole library, so any bad author name plus that middleware raises `TypeError` out of `parse_string`. I store `name`/`reason` and add `__reduce__` so it round-trips. Added a test.
