### PR TITLE
🔧 Drop dead `library` parameter from `Splitter.split()`

### DIFF
--- a/bibtexparser/splitter.py
+++ b/bibtexparser/splitter.py
@@ -275,22 +275,17 @@ class Splitter:
                     end_index=after_field_mark.start(),
                 )
 
-    def split(self, library: Library | None = None) -> Library:
-        """Split the bibtex-string into blocks and add them to the library.
+    def split(self) -> Library:
+        """Split the bibtex-string into blocks and return them as a new library.
 
-        Args:
-            library: The library to add the blocks to. If None, a new library is created.
         Returns:
-            The library with the added blocks.
+            A new library containing the split blocks.
         """
         self._markiter = re.finditer(
             r"(?<!\\)[\{\}\",=\n]|@[\w]*( |\t)*(?={)", self.bibstr, re.MULTILINE
         )
 
-        if library is None:
-            library = Library()
-        else:
-            logger.info("Adding blocks to existing library.")
+        library = Library()
 
         while True:
             m = self._next_mark(accept_eof=True)


### PR DESCRIPTION
Since #603, `parse_string` builds a fresh `Library` and merges the result instead of passing the caller's library into the splitter. That left `Splitter.split(library=...)` with no caller: nothing in `bibtexparser/`, `tests/`, `docs/`, the README or the notebooks passes it.

Removed the parameter, so `split()` always returns a new `Library` (the dead `logger.info("Adding blocks to existing library.")` branch goes with it). Breaking change to a public signature, which seems right to take now while 2.0.0 is unreleased (2.0.0b9, #609). `Splitter` and `split()` stay public and unrenamed; no test called `split(library=...)`, so no test changes.

Merges cleanly with both #598 and #602 — I trial-merged each; #598 touches the adjacent mark regex but does not conflict.

2589 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)