### PR TITLE
🔧 Only run unittests on pushes to main

### DIFF
--- a/.github/workflows/linting_and_unittests.yml
+++ b/.github/workflows/linting_and_unittests.yml
@@ -2,6 +2,7 @@ name: "unittests"
 
 on:
   push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 


### PR DESCRIPTION
`push:` in `linting_and_unittests.yml` has no branch filter, so every push to a PR branch queues the 15-job matrix **twice**: once for `push`, once for `pull_request`. Verified on the current queue, e.g. `fix/block-hash` has both a `unittests/push` and a `unittests/pull_request` run for the same commit.

Scoping `push:` to `main` matches what `pre-commit.yml` and `codeql-analysis.yml` already do, and halves CI load on every PR branch push. Pushes to main and all pull request runs are unaffected.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
