### PR TITLE
📦 Ship the complete test tree and its resources in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+# The sdist ships the full test suite, so that it can be run from source.
+graft tests
+
+global-exclude __pycache__ *.py[cod]


### PR DESCRIPTION
The sdist only shipped the four top-level `test*.py` files that setuptools picks up by default. `tests/resources/` and the `splitter_tests` / `middleware_tests` subpackages were missing, so running the suite from an unpacked sdist failed with `FileNotFoundError: tests/resources/gbk_test.bib`.

Fix: add a `MANIFEST.in` that grafts `tests` (with a `global-exclude` for `__pycache__` / `*.pyc` so stale caches do not leak in).

Verified:
- `pytest -q` in an unpacked sdist: 2730 passed, 12 skipped — identical to a checkout.
- Wheel unchanged, still contains no tests (`[tool.setuptools.packages.find]` keeps it to `bibtexparser*`).
- No caches or build artefacts added to the sdist.

Fixes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)