### PR TITLE
🔧 Re-enable and modernize CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,24 +1,14 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
     branches: ["main", "v1"]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: ["main", "v1"]
   schedule:
-  - cron: '25 22 * * 1'
+    - cron: '25 22 * * 1'
+  # Manual trigger, e.g. to refresh stale results.
+  workflow_dispatch:
 
 jobs:
   analyze:
@@ -33,40 +23,17 @@ jobs:
       fail-fast: false
       matrix:
         language: ['python']
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: ["main", "v1"]
   schedule:
-    - cron: '25 22 * * 1'
+  - cron: '25 22 * * 1'
   # Manual trigger, e.g. to refresh stale results.
   workflow_dispatch:
 


### PR DESCRIPTION
**Problem:** The Security tab shows "Code Scanning results may be out of date" for \`language:python\`. GitHub disabled the scheduled CodeQL workflow (\`disabled_inactivity\`) after 60 days without commits, so no scan ran after May 4, 2026, and disabled workflows don't fire on push either.

**Fix:** Re-enabled the workflow via \`gh workflow enable\` (done). This PR additionally moves the workflow off the retired \`codeql-action@v2\` / \`checkout@v3\` to \`v4\` / \`v6\`, drops the no-op Autobuild step (Python needs no build), and adds \`workflow_dispatch\` so a scan can be triggered by hand.

**Verification:** The CodeQL check on this PR runs the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)